### PR TITLE
fix: #4 normalize font paths to use forward slashes for embed.FS compatibility on Windows

### DIFF
--- a/internal/ui/font_loader.go
+++ b/internal/ui/font_loader.go
@@ -24,7 +24,9 @@ func loadFontList() ([]FontInfo, error) {
 	for _, entry := range entries {
 		if filepath.Ext(entry.Name()) == ".bit" {
 			fontPath := filepath.Join("fonts", entry.Name())
-
+			if strings.Contains(fontPath, "\\") {
+				fontPath = strings.ReplaceAll(fontPath, "\\", "/")
+			}
 			// For lazy loading, we only load the font name from the file
 			// This is much more efficient than loading the entire font data
 			fontDataBytes, err := ansifonts.EmbeddedFonts.ReadFile(fontPath)


### PR DESCRIPTION
Ensures font paths use forward slashes regardless of OS, preventing
path resolution issues with Go's embedded filesystem on Windows.

Fix verified:

<img width="1838" height="1050" alt="image" src="https://github.com/user-attachments/assets/7029069d-d453-4dcb-a272-a23465653613" />

