### PR TITLE
Introduce PNG export with correct aspect ratio and Desktop save location

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,37 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+permissions:
+  contents: write
+  packages: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Install dependencies
+        run: go mod download
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          distribution: goreleaser
+          version: '~> v2'
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,107 @@
+version: 2
+
+project_name: bit
+
+before:
+  hooks:
+    - go mod tidy
+
+builds:
+  - id: bit
+    binary: bit
+    main: ./cmd/bit
+    goos:
+      - linux
+      - darwin
+      - windows
+    goarch:
+      - amd64
+      - arm64
+    env:
+      - CGO_ENABLED=0
+    ldflags:
+      - -s -w
+      - -X main.version={{ .Version }}
+      - -X main.commit={{ .Commit }}
+      - -X main.date={{ .Date }}
+
+archives:
+  - name_template: >-
+      {{ .ProjectName }}_
+      {{- .Version }}_
+      {{- title .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "386" }}i386
+      {{- else }}{{ .Arch }}{{ end }}
+    files:
+      - LICENSE
+      - README.md
+      - ansifonts/README.md
+
+checksum:
+  name_template: checksums.txt
+
+snapshot:
+  version_template: "{{ incpatch .Version }}-next"
+
+changelog:
+  sort: asc
+  use: github
+  filters:
+    exclude:
+      - '^docs:'
+      - '^test:'
+      - '^chore:'
+      - Merge pull request
+      - Merge branch
+  groups:
+    - title: Features
+      regexp: '^.*feat(\(.+\))?!?:'
+      order: 0
+    - title: Bug fixes
+      regexp: '^.*fix(\(.+\))?!?:'
+      order: 1
+    - title: Others
+      order: 999
+
+release:
+  github:
+    owner: superstarryeyes
+    name: bit
+  draft: false
+  prerelease: auto
+  mode: replace
+  header: |
+    ## Bit {{ .Tag }} Release
+
+    Terminal ANSI Logo Designer & Font Library with 100+ bitmap fonts
+
+    ### Quick Install
+
+    **Linux/macOS**
+    ```bash
+    curl -sfL https://raw.githubusercontent.com/superstarryeyes/bit/main/install.sh | sh
+    ```
+
+    **Manual Download**
+    Pick the archive for your platform below.
+
+  footer: |
+    ---
+    
+    **Full Changelog:** https://github.com/superstarryeyes/bit/compare/{{ .PreviousTag }}...{{ .Tag }}
+    
+    ### What's Included
+    
+    Each archive contains:
+    - `bit` binary (interactive UI + CLI mode)
+    - Documentation and license files
+    
+    ### Usage
+    
+    ```bash
+    bit              # Start interactive UI
+    bit -list        # List all fonts
+    bit "Hello"      # Quick render
+    bit -help        # Show all options
+    ```

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,70 @@
+.PHONY: help build build-all clean test snapshot install
+
+# Directories
+BIN_DIR := bin
+CMD_DIR := ./cmd/bit
+
+help:
+	@echo "Bit - Terminal ANSI Logo Designer"
+	@echo ""
+	@echo "Available targets:"
+	@echo "  make build          - Build bit binary"
+	@echo "  make build-all      - Build for all platforms"
+	@echo "  make clean          - Remove build artifacts"
+	@echo "  make test           - Run tests"
+	@echo "  make snapshot       - Test GoReleaser build (no publish)"
+	@echo "  make install        - Install binary to /usr/local/bin"
+
+# Build single binary
+build:
+	@echo "Building bit..."
+	@mkdir -p $(BIN_DIR)
+	go build -o $(BIN_DIR)/bit $(CMD_DIR)
+	@echo "Done! Binary in ./$(BIN_DIR)/"
+
+# Build for all platforms
+build-all:
+	@echo "Building for all platforms..."
+	@mkdir -p $(BIN_DIR)
+	GOOS=linux   GOARCH=amd64 go build -o $(BIN_DIR)/bit-linux-amd64 $(CMD_DIR)
+	GOOS=linux   GOARCH=arm64 go build -o $(BIN_DIR)/bit-linux-arm64 $(CMD_DIR)
+	GOOS=darwin  GOARCH=amd64 go build -o $(BIN_DIR)/bit-darwin-amd64 $(CMD_DIR)
+	GOOS=darwin  GOARCH=arm64 go build -o $(BIN_DIR)/bit-darwin-arm64 $(CMD_DIR)
+	GOOS=windows GOARCH=amd64 go build -o $(BIN_DIR)/bit-windows-amd64.exe $(CMD_DIR)
+	GOOS=windows GOARCH=arm64 go build -o $(BIN_DIR)/bit-windows-arm64.exe $(CMD_DIR)
+	@echo "Done! Binaries in ./$(BIN_DIR)/"
+
+# Clean
+clean:
+	@echo "Cleaning build artifacts..."
+	rm -rf $(BIN_DIR)/
+	rm -rf dist/
+	@echo "Done!"
+
+# Run tests
+test:
+	@echo "Running tests..."
+	go test -v ./...
+
+# Test GoReleaser build locally
+snapshot:
+	@echo "Running GoReleaser snapshot build..."
+	@if ! command -v goreleaser >/dev/null 2>&1; then \
+		echo "Error: goreleaser not found. Install with: brew install goreleaser"; \
+		exit 1; \
+	fi
+	goreleaser release --snapshot --clean
+	@echo ""
+	@echo "Snapshot build complete! Artifacts in ./dist/"
+	@echo ""
+	@echo "Test the binaries:"
+	@echo "  ls dist/bit_*/bit"
+	@echo "  ./dist/bit_*/bit -version"
+	@echo "  ./dist/bit_*/bit -list"
+	@echo "  ./dist/bit_*/bit \"Hello\""
+
+# Install binary globally
+install: build
+	@echo "Installing binary to /usr/local/bin..."
+	@sudo cp $(BIN_DIR)/bit /usr/local/bin/bit
+	@echo "Done! Run 'bit' from anywhere."

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 | **Feature**                             | **Description**                                                                                |
 | --------------------------------------- | ---------------------------------------------------------------------------------------------- |
 | **🌟 100+ Font Styles**               | Classic terminal, retro gaming, modern pixel, decorative, and monospace fonts. All free for commercial and personal use.                  |
-| **📤 Multi-Format Export**              | Export to TXT, Go, JavaScript, Python, Rust, and Bash with language-specific formatting.               |
+| **📤 Multi-Format Export**              | Export to PNG, TXT, Go, JavaScript, Python, Rust, and Bash. PNG exports to Desktop with transparent background.               |
 | **🎨 Advanced Text Effects**            | Color gradient effects (horizontal & vertical), shadow effects (horizontal & vertical), and text scaling (0.5×–4×).|
 | **🌈 Rich Color Support**               | 14 vibrant predefined UI colors that can be combined with gradients. The library and CLI also accept any hex color for unlimited possibilities.|
 | **📐 Alignment & Spacing**                   | Adjust character, word, and line spacing. Align text left, center, or right.          |
@@ -337,6 +337,7 @@ The interactive UI supports exporting your creations to:
 
 | Format | Extension | Description |
 |--------|-----------|-------------|
+| **PNG** | `.png` | PNG image with transparent background |
 | **TXT** | `.txt` | Plain text with ANSI codes stripped |
 | **Go** | `.go` | Go source code with embedded ANSI strings |
 | **JavaScript** | `.js` | JavaScript array with console.log display function |
@@ -348,6 +349,8 @@ All exports include:
 - Properly escaped ANSI sequences
 - Language-specific string literals
 - Ready-to-run code
+
+PNG exports are saved to your Desktop by default and preserve the exact appearance of your terminal art with transparent backgrounds.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -52,25 +52,51 @@ go build -o bit ./cmd/bit
 
 ## 📦 Installation
 
-### Prerequisites
+### Quick Install (Linux/macOS)
 
-- **Go 1.25+** - Required for proper module support
+```bash
+curl -sfL https://raw.githubusercontent.com/superstarryeyes/bit/main/install.sh | sh
+```
 
-### Build Commands
+This installs `bit` to `/usr/local/bin`. The binary works in two modes:
+- **Interactive UI**: Run `bit` with no arguments
+- **CLI mode**: Run `bit [options] <text>` to render directly
+
+### Manual Installation
+
+Download the latest release for your platform from the [Releases page](https://github.com/superstarryeyes/bit/releases).
+
+**Available for:**
+- Linux (x86_64, arm64)
+- macOS (x86_64, arm64)
+- Windows (x86_64, arm64)
+
+**Extract and install:**
+
+```bash
+# Linux/macOS
+tar -xzf bit_*_Linux_x86_64.tar.gz
+sudo mv bit /usr/local/bin/
+
+# Windows (PowerShell)
+Expand-Archive bit_*_Windows_x86_64.zip
+# Move bit.exe to your PATH
+```
+
+### Build from Source
+
+**Prerequisites:** Go 1.25+
 
 ```bash
 # Clone repository
 git clone https://github.com/superstarryeyes/bit
 cd bit
 
-# Install dependencies
-go mod tidy
+# Build the binary
+make build
 
-# Build the interactive UI (includes embedded fonts)
+# Or manually
 go build -o bit ./cmd/bit
-
-# Build the command line tool
-go build -o ansifonts-cli ./cmd/ansifonts
 ```
 
 > [!NOTE]
@@ -80,7 +106,26 @@ go build -o ansifonts-cli ./cmd/ansifonts
 
 ## 💻 Usage
 
-### Keyboard Controls
+### Running Bit
+
+```bash
+# Start interactive UI
+bit
+
+# CLI mode - quick render
+bit "Hello World"
+
+# CLI mode - with options
+bit -font ithaca -color 31 "Red Text"
+
+# List all fonts
+bit -list
+
+# Show help
+bit -help
+```
+
+### Interactive UI - Keyboard Controls
 
 | **Key Binding**                         | **Action Description**                                                                         |
 | --------------------------------------- | ---------------------------------------------------------------------------------------------- |
@@ -137,40 +182,42 @@ The UI features **6 main control panels** with sub-modes accessible via **Tab** 
 > [!WARNING]
 > If shadows are enabled with half-pixel characters, a warning appears in the title bar. The library automatically disables shadows in this case to prevent visual artifacts.
 
-### Command Line Tool
+### CLI Mode
+
+The `bit` binary includes a powerful CLI mode for quick text rendering:
 
 #### Basic Commands
 
 ```bash
 # Render text with default settings
-./ansifonts-cli "Hello"
+bit "Hello"
 
 # List all available fonts
-./ansifonts-cli -list
+bit -list
 
 # Use specific font and color (ANSI code)
-./ansifonts-cli -font ithaca -color 31 "Red"
+bit -font ithaca -color 31 "Red"
 
 # Use specific font and color (hex code)
-./ansifonts-cli -font ithaca -color "#FF0000" "Red"
+bit -font ithaca -color "#FF0000" "Red"
 
 # Gradient text with ANSI codes
-./ansifonts-cli -font dogica -color 31 -gradient 34 -direction right "Gradient"
+bit -font dogica -color 31 -gradient 34 -direction right "Gradient"
 
 # Gradient text with hex codes
-./ansifonts-cli -font dogica -color "#FF0000" -gradient "#0000FF" "Gradient"
+bit -font dogica -color "#FF0000" -gradient "#0000FF" "Gradient"
 
 # Text with shadow
-./ansifonts-cli -font larceny -color 94 -shadow -shadow-h 2 -shadow-v 1 "Shadow"
+bit -font larceny -color 94 -shadow -shadow-h 2 -shadow-v 1 "Shadow"
 
 # Scaled text
-./ansifonts-cli -font pressstart -color 32 -scale 1 "2X"
+bit -font pressstart -color 32 -scale 1 "2X"
 
 # Aligned text
-./ansifonts-cli -font gohufontb -color 93 -align right "Go\nRight"
+bit -font gohufontb -color 93 -align right "Go\nRight"
 ```
 
-#### Command Line Options
+#### CLI Options
 
 | **Flag**          | **Description**                | **Values**                              |
 | ----------------- | ------------------------------ | --------------------------------------- |

--- a/ansifonts/loader.go
+++ b/ansifonts/loader.go
@@ -6,72 +6,19 @@ package ansifonts
 import (
 	"embed"
 	"encoding/json"
-	"os"
-	"path/filepath"
+	"path"
 	"strings"
-
-	"golang.org/x/text/cases"
-	"golang.org/x/text/language"
 )
 
 //go:embed fonts/*.bit
 var EmbeddedFonts embed.FS
 
-// findFontsDir searches for the fonts directory relative to the package
-func findFontsDir() (string, error) {
-	// Try package-relative fonts directory first (for library usage)
-	// This assumes the fonts are in ansifonts/fonts/
-	if _, err := os.Stat("ansifonts/fonts"); err == nil {
-		return "ansifonts/fonts", nil
-	}
-
-	// Try current directory (for when running from ansifonts/ directory)
-	if _, err := os.Stat("fonts"); err == nil {
-		return "fonts", nil
-	}
-
-	// Try parent directory (for cmd/ executables)
-	if _, err := os.Stat("../ansifonts/fonts"); err == nil {
-		return "../ansifonts/fonts", nil
-	}
-
-	// Legacy fallback for old structure
-	if _, err := os.Stat("../fonts"); err == nil {
-		return "../fonts", nil
-	}
-
-	return "", os.ErrNotExist
-}
-
-// LoadFont loads a font by name from the fonts directory
+// LoadFont loads a font by name from the embedded fonts directory
 func LoadFont(name string) (*Font, error) {
-	fontsDir, err := findFontsDir()
-	if err != nil {
-		return nil, err
-	}
+	// Construct the path using forward slashes for embedded filesystem
+	fontPath := path.Join("fonts", name+".bit")
 
-	// Try to load from the fonts directory
-	fontPath := filepath.Join(fontsDir, name+".bit")
-
-	// Check if the file exists
-	if _, err := os.Stat(fontPath); os.IsNotExist(err) {
-		// Try with different case variations
-		titleCaser := cases.Title(language.English)
-		variations := []string{
-			strings.ToLower(name) + ".bit",
-			strings.ToUpper(name) + ".bit",
-			titleCaser.String(strings.ToLower(name)) + ".bit",
-		}
-
-		for _, variation := range variations {
-			fontPath = filepath.Join(fontsDir, variation)
-			if _, err := os.Stat(fontPath); err == nil {
-				break
-			}
-		}
-	}
-
-	fontBytes, err := os.ReadFile(fontPath)
+	fontBytes, err := EmbeddedFonts.ReadFile(fontPath)
 	if err != nil {
 		return nil, err
 	}
@@ -88,21 +35,16 @@ func LoadFont(name string) (*Font, error) {
 	}, nil
 }
 
-// ListFonts returns a list of available font names from the fonts directory
+// ListFonts returns a list of available font names from the embedded fonts directory
 func ListFonts() ([]string, error) {
-	fontsDir, err := findFontsDir()
-	if err != nil {
-		return nil, err
-	}
-
-	entries, err := os.ReadDir(fontsDir)
+	entries, err := EmbeddedFonts.ReadDir("fonts")
 	if err != nil {
 		return nil, err
 	}
 
 	var fonts []string
 	for _, entry := range entries {
-		if !entry.IsDir() && filepath.Ext(entry.Name()) == ".bit" {
+		if !entry.IsDir() && path.Ext(entry.Name()) == ".bit" {
 			fontName := strings.TrimSuffix(entry.Name(), ".bit")
 			fonts = append(fonts, fontName)
 		}

--- a/cmd/bit/main.go
+++ b/cmd/bit/main.go
@@ -1,23 +1,241 @@
 package main
 
 import (
+	"flag"
 	"fmt"
 	"os"
+	"strings"
 
+	"github.com/superstarryeyes/bit/ansifonts"
 	"github.com/superstarryeyes/bit/internal/ui"
 	tea "github.com/charmbracelet/bubbletea"
 )
 
 func main() {
-	m, err := ui.InitialModel()
+	// Define CLI flags
+	var fontName string
+	var textColor string
+	var gradientColor string
+	var gradientDirection string
+	var charSpacing int
+	var wordSpacing int
+	var lineSpacing int
+	var scaleInt int
+	var shadowEnabled bool
+	var shadowH int
+	var shadowV int
+	var shadowStyle int
+	var alignment string
+	var list bool
+	var version bool
+
+	flag.StringVar(&fontName, "font", "", "Font name to use (default: first available font)")
+	flag.StringVar(&textColor, "color", "", "Text color: ANSI code (31) or hex (#FF0000)")
+	flag.StringVar(&gradientColor, "gradient", "", "Gradient end color: ANSI code (34) or hex (#0000FF)")
+	flag.StringVar(&gradientDirection, "direction", "down", "Gradient direction: down, up, right, left")
+	flag.IntVar(&charSpacing, "char-spacing", 2, "Character spacing (0 to 10)")
+	flag.IntVar(&wordSpacing, "word-spacing", 2, "Word spacing (0 to 20)")
+	flag.IntVar(&lineSpacing, "line-spacing", 1, "Line spacing (0 to 10)")
+	flag.IntVar(&scaleInt, "scale", 0, "Text scale: -1 (0.5x), 0 (1x), 1 (2x), 2 (4x)")
+	flag.BoolVar(&shadowEnabled, "shadow", false, "Enable shadow effect")
+	flag.IntVar(&shadowH, "shadow-h", 1, "Shadow horizontal offset (-5 to 5)")
+	flag.IntVar(&shadowV, "shadow-v", 1, "Shadow vertical offset (-5 to 5)")
+	flag.IntVar(&shadowStyle, "shadow-style", 1, "Shadow style: 0 (light), 1 (medium), 2 (dark)")
+	flag.StringVar(&alignment, "align", "center", "Text alignment: left, center, right")
+	flag.BoolVar(&list, "list", false, "List all available fonts")
+	flag.BoolVar(&version, "version", false, "Show version information")
+
+	flag.Usage = func() {
+		fmt.Fprintf(os.Stderr, "Bit - Terminal ANSI Logo Designer & Font Library\n\n")
+		fmt.Fprintf(os.Stderr, "Usage:\n")
+		fmt.Fprintf(os.Stderr, "  bit                    Start interactive UI\n")
+		fmt.Fprintf(os.Stderr, "  bit [options] <text>   Render text with CLI options\n\n")
+		fmt.Fprintf(os.Stderr, "Options:\n")
+		flag.PrintDefaults()
+		fmt.Fprintf(os.Stderr, "\nColor Codes:\n")
+		fmt.Fprintf(os.Stderr, "  30=black         31=red              32=green          33=yellow\n")
+		fmt.Fprintf(os.Stderr, "  34=blue          35=magenta          36=cyan           37=white\n")
+		fmt.Fprintf(os.Stderr, "  90=gray          91=bright-red       92=bright-green   93=bright-yellow\n")
+		fmt.Fprintf(os.Stderr, "  94=bright-blue   95=bright-magenta   96=bright-cyan\n")
+		fmt.Fprintf(os.Stderr, "\nExamples:\n")
+		fmt.Fprintf(os.Stderr, "  bit                                                    # Start interactive UI\n")
+		fmt.Fprintf(os.Stderr, "  bit -list                                              # List all fonts\n")
+		fmt.Fprintf(os.Stderr, "  bit \"Hello World\"                                      # Quick render\n")
+		fmt.Fprintf(os.Stderr, "  bit -font ithaca -color 31 \"Red\"                       # With font and color\n")
+		fmt.Fprintf(os.Stderr, "  bit -font ithaca -color \"#FF0000\" \"Red Hex\"            # Hex color\n")
+		fmt.Fprintf(os.Stderr, "  bit -font dogica -color 31 -gradient 34 \"Gradient\"     # Gradient\n")
+		fmt.Fprintf(os.Stderr, "  bit -font pressstart -color 32 -shadow \"Shadow\"        # With shadow\n")
+	}
+
+	flag.Parse()
+
+	// Show version
+	if version {
+		fmt.Println("Bit - Terminal ANSI Logo Designer & Font Library")
+		fmt.Println("Version: 0.1.0")
+		fmt.Println("https://github.com/superstarryeyes/bit")
+		return
+	}
+
+	// List fonts
+	if list {
+		fonts, err := ansifonts.ListFonts()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error listing fonts: %v\n", err)
+			os.Exit(1)
+		}
+
+		fmt.Println("Available fonts:")
+		for _, font := range fonts {
+			fmt.Printf("  %s\n", font)
+		}
+		return
+	}
+
+	// If no arguments provided, start interactive UI
+	if flag.NArg() == 0 && !list && !version {
+		m, err := ui.InitialModel()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error initializing application: %v\n", err)
+			os.Exit(1)
+		}
+
+		p := tea.NewProgram(m, tea.WithAltScreen())
+		if _, err := p.Run(); err != nil {
+			fmt.Fprintf(os.Stderr, "Error running application: %v\n", err)
+			os.Exit(1)
+		}
+		return
+	}
+
+	// CLI mode: render text
+	text := strings.Join(flag.Args(), " ")
+	if text == "" {
+		text = "Hello"
+	}
+
+	// Replace literal \n with actual newlines
+	text = strings.ReplaceAll(text, "\\n", "\n")
+
+	// If no font specified, use the first available font
+	if fontName == "" {
+		fonts, err := ansifonts.ListFonts()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error listing fonts: %v\n", err)
+			os.Exit(1)
+		}
+		if len(fonts) == 0 {
+			fmt.Fprintf(os.Stderr, "No fonts available\n")
+			os.Exit(1)
+		}
+		fontName = fonts[0]
+	}
+
+	// Load the font
+	font, err := ansifonts.LoadFont(fontName)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error initializing application: %v\n", err)
+		fmt.Fprintf(os.Stderr, "Error loading font '%s': %v\n", fontName, err)
 		os.Exit(1)
 	}
 
-	p := tea.NewProgram(m, tea.WithAltScreen())
-	if _, err := p.Run(); err != nil {
-		fmt.Fprintf(os.Stderr, "Error running application: %v\n", err)
-		os.Exit(1)
+	// Helper function to parse color (ANSI code or hex)
+	parseColor := func(colorInput string, defaultColor string) string {
+		if colorInput == "" {
+			return defaultColor
+		}
+		// Check if it's a hex color (starts with #)
+		if strings.HasPrefix(colorInput, "#") {
+			// Validate hex format
+			if len(colorInput) == 7 {
+				return colorInput
+			}
+			fmt.Fprintf(os.Stderr, "Warning: Invalid hex color '%s', using default\n", colorInput)
+			return defaultColor
+		}
+		// Try ANSI code mapping using centralized color map
+		if color, ok := ansifonts.ANSIColorMap[colorInput]; ok {
+			return color
+		}
+		fmt.Fprintf(os.Stderr, "Warning: Unknown color code '%s', using default\n", colorInput)
+		return defaultColor
+	}
+
+	// Convert scaleInt to actual scale factor
+	var scale float64
+	switch scaleInt {
+	case -1:
+		scale = 0.5 // 0.5x
+	case 0:
+		scale = 1.0 // 1x
+	case 1:
+		scale = 2.0 // 2x
+	case 2:
+		scale = 4.0 // 4x
+	default:
+		scale = 1.0 // Default to 1x if invalid value provided
+		fmt.Fprintf(os.Stderr, "Warning: Invalid scale value '%d', using default scale (1x)\n", scaleInt)
+	}
+
+	// Build render options
+	options := ansifonts.RenderOptions{
+		CharSpacing: charSpacing,
+		WordSpacing: wordSpacing,
+		LineSpacing: lineSpacing,
+		ScaleFactor: scale,
+	}
+
+	// Set alignment
+	switch alignment {
+	case "left":
+		options.Alignment = ansifonts.LeftAlign
+	case "center":
+		options.Alignment = ansifonts.CenterAlign
+	case "right":
+		options.Alignment = ansifonts.RightAlign
+	default:
+		options.Alignment = ansifonts.CenterAlign
+	}
+
+	// Set colors (supports both ANSI codes and hex)
+	options.TextColor = parseColor(textColor, "#FFFFFF")
+
+	// Set gradient
+	if gradientColor != "" {
+		options.GradientColor = parseColor(gradientColor, options.TextColor)
+
+		// Set gradient direction
+		switch gradientDirection {
+		case "down":
+			options.GradientDirection = ansifonts.UpDown
+		case "up":
+			options.GradientDirection = ansifonts.DownUp
+		case "right":
+			options.GradientDirection = ansifonts.LeftRight
+		case "left":
+			options.GradientDirection = ansifonts.RightLeft
+		default:
+			options.GradientDirection = ansifonts.UpDown
+		}
+
+		options.UseGradient = true
+	}
+
+	// Set shadow
+	if shadowEnabled {
+		options.ShadowEnabled = true
+		options.ShadowHorizontalOffset = shadowH
+		options.ShadowVerticalOffset = shadowV
+
+		// Validate shadow style
+		if shadowStyle < 0 || shadowStyle > 2 {
+			shadowStyle = 1
+		}
+		options.ShadowStyle = ansifonts.ShadowStyle(shadowStyle)
+	}
+
+	// Render and print
+	rendered := ansifonts.RenderTextWithOptions(text, font, options)
+	for _, line := range rendered {
+		fmt.Println(line)
 	}
 }

--- a/cmd/bit/main.go
+++ b/cmd/bit/main.go
@@ -72,7 +72,7 @@ func main() {
 	// Show version
 	if version {
 		fmt.Println("Bit - Terminal ANSI Logo Designer & Font Library")
-		fmt.Println("Version: 0.1.0")
+		fmt.Println("Version: 0.2.0")
 		fmt.Println("https://github.com/superstarryeyes/bit")
 		return
 	}

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,86 @@
+#!/bin/sh
+set -e
+
+# Bit installer script
+# Usage: curl -sfL https://raw.githubusercontent.com/superstarryeyes/bit/main/install.sh | sh
+
+# Detect OS and architecture
+OS=$(uname -s | tr '[:upper:]' '[:lower:]')
+ARCH=$(uname -m)
+
+case "$OS" in
+    linux)
+        OS="Linux"
+        ;;
+    darwin)
+        OS="Darwin"
+        ;;
+    *)
+        echo "Unsupported operating system: $OS"
+        exit 1
+        ;;
+esac
+
+case "$ARCH" in
+    x86_64)
+        ARCH="x86_64"
+        ;;
+    amd64)
+        ARCH="x86_64"
+        ;;
+    arm64|aarch64)
+        ARCH="arm64"
+        ;;
+    *)
+        echo "Unsupported architecture: $ARCH"
+        exit 1
+        ;;
+esac
+
+# Get latest release version
+LATEST_VERSION=$(curl -s https://api.github.com/repos/superstarryeyes/bit/releases/latest | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/')
+
+if [ -z "$LATEST_VERSION" ]; then
+    echo "Failed to get latest version"
+    exit 1
+fi
+
+echo "Installing Bit $LATEST_VERSION for $OS $ARCH..."
+
+# Construct download URL
+FILENAME="bit_${LATEST_VERSION#v}_${OS}_${ARCH}.tar.gz"
+URL="https://github.com/superstarryeyes/bit/releases/download/$LATEST_VERSION/$FILENAME"
+
+# Create temp directory
+TMP_DIR=$(mktemp -d)
+cd "$TMP_DIR"
+
+# Download and extract
+echo "Downloading $URL..."
+curl -sfL "$URL" -o "$FILENAME"
+
+echo "Extracting..."
+tar -xzf "$FILENAME"
+
+# Install binary
+INSTALL_DIR="/usr/local/bin"
+
+if [ -w "$INSTALL_DIR" ]; then
+    mv bit "$INSTALL_DIR/"
+else
+    echo "Installing to $INSTALL_DIR (requires sudo)..."
+    sudo mv bit "$INSTALL_DIR/"
+fi
+
+# Cleanup
+cd -
+rm -rf "$TMP_DIR"
+
+echo ""
+echo "✓ Bit installed successfully!"
+echo ""
+echo "Usage:"
+echo "  bit              - Start interactive UI"
+echo "  bit -list        - List all available fonts"
+echo "  bit \"Hello\"    - Quick render text"
+echo "  bit -help        - Show all options"

--- a/internal/export/integration_test.go
+++ b/internal/export/integration_test.go
@@ -1,0 +1,79 @@
+// ABOUTME: Integration tests for PNG export functionality.
+// ABOUTME: Tests the full pipeline from ANSI input to PNG file output.
+
+//go:build integration
+// +build integration
+
+package export
+
+import (
+	"bytes"
+	"image/png"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestPNGExportIntegration tests the full export pipeline
+func TestPNGExportIntegration(t *testing.T) {
+	// Sample ANSI-colored output (red "H" in block characters)
+	lines := []string{
+		"\x1b[38;2;255;0;0m█\x1b[0m  \x1b[38;2;255;0;0m█\x1b[0m",
+		"\x1b[38;2;255;0;0m█\x1b[0m  \x1b[38;2;255;0;0m█\x1b[0m",
+		"\x1b[38;2;255;0;0m████\x1b[0m",
+		"\x1b[38;2;255;0;0m█\x1b[0m  \x1b[38;2;255;0;0m█\x1b[0m",
+		"\x1b[38;2;255;0;0m█\x1b[0m  \x1b[38;2;255;0;0m█\x1b[0m",
+	}
+
+	// Generate PNG
+	data, err := GeneratePNG(lines, DefaultPNGOptions())
+	if err != nil {
+		t.Fatalf("GeneratePNG failed: %v", err)
+	}
+
+	// Verify PNG is valid
+	img, err := png.Decode(bytes.NewReader(data))
+	if err != nil {
+		t.Fatalf("PNG decode failed: %v", err)
+	}
+
+	// Verify dimensions (4 chars wide x 5 lines = 64x80 pixels at 16x scale)
+	bounds := img.Bounds()
+	expectedWidth := 4 * CellSize  // 64
+	expectedHeight := 5 * CellSize // 80
+	if bounds.Dx() != expectedWidth || bounds.Dy() != expectedHeight {
+		t.Errorf("expected %dx%d, got %dx%d", expectedWidth, expectedHeight, bounds.Dx(), bounds.Dy())
+	}
+
+	// Write to temp file for manual inspection
+	tmpDir := t.TempDir()
+	tmpFile := filepath.Join(tmpDir, "test_output.png")
+	if err := os.WriteFile(tmpFile, data, 0644); err != nil {
+		t.Fatalf("failed to write temp file: %v", err)
+	}
+	t.Logf("PNG written to: %s (%d bytes)", tmpFile, len(data))
+
+	// Verify file was created and has content
+	info, err := os.Stat(tmpFile)
+	if err != nil {
+		t.Fatalf("failed to stat temp file: %v", err)
+	}
+	if info.Size() == 0 {
+		t.Error("PNG file is empty")
+	}
+}
+
+// TestExportManagerBinaryExport tests the ExportManager.ExportBinary method
+func TestExportManagerBinaryExport(t *testing.T) {
+	em := NewExportManager()
+
+	// Verify PNG is recognized as binary
+	if !em.IsBinaryFormat("PNG") {
+		t.Error("PNG should be identified as binary format")
+	}
+
+	// Verify TXT is not binary
+	if em.IsBinaryFormat("TXT") {
+		t.Error("TXT should not be identified as binary format")
+	}
+}

--- a/internal/export/manager.go
+++ b/internal/export/manager.go
@@ -26,13 +26,26 @@ func stripANSI(s string) string {
 // ExportManager handles exporting text in various formats
 type ExportManager struct {
 	formats []ExportFormat
+	basePath string // Base directory for exports (defaults to Desktop)
 }
 
 // NewExportManager creates a new export manager with supported formats
 func NewExportManager() *ExportManager {
 	return &ExportManager{
-		formats: SupportedFormats,
+		formats:  SupportedFormats,
+		basePath: getDesktopPath(),
 	}
+}
+
+// getDesktopPath returns the user's Desktop directory path
+func getDesktopPath() string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		// Fallback to current directory if we can't get home
+		cwd, _ := os.Getwd()
+		return cwd
+	}
+	return filepath.Join(home, "Desktop")
 }
 
 // GetSupportedFormats returns the list of supported export formats
@@ -66,17 +79,11 @@ func (em *ExportManager) Export(content, filename, formatName string) error {
 		filename += format.Extension
 	}
 
-	// Get current working directory
-	cwd, err := os.Getwd()
-	if err != nil {
-		return fmt.Errorf("failed to get current directory: %v", err)
-	}
-
 	// Create full file path using filepath.Join for safety
-	filePath := filepath.Join(cwd, filepath.Base(filename))
+	filePath := filepath.Join(em.basePath, filepath.Base(filename))
 
 	// Write content to file
-	err = os.WriteFile(filePath, []byte(content), 0644)
+	err := os.WriteFile(filePath, []byte(content), 0644)
 	if err != nil {
 		return fmt.Errorf("failed to write file: %v", err)
 	}
@@ -114,17 +121,11 @@ func (em *ExportManager) ExportBinary(content []byte, filename, formatName strin
 		filename += format.Extension
 	}
 
-	// Get current working directory
-	cwd, err := os.Getwd()
-	if err != nil {
-		return fmt.Errorf("failed to get current directory: %v", err)
-	}
-
 	// Create full file path using filepath.Join for safety
-	filePath := filepath.Join(cwd, filepath.Base(filename))
+	filePath := filepath.Join(em.basePath, filepath.Base(filename))
 
 	// Write binary content to file
-	err = os.WriteFile(filePath, content, 0644)
+	err := os.WriteFile(filePath, content, 0644)
 	if err != nil {
 		return fmt.Errorf("failed to write file: %v", err)
 	}
@@ -167,14 +168,8 @@ func (em *ExportManager) CheckFileExists(filename, formatName string) (bool, str
 		filename += format.Extension
 	}
 
-	// Get current working directory
-	cwd, err := os.Getwd()
-	if err != nil {
-		return false, "", fmt.Errorf("failed to get current directory: %v", err)
-	}
-
 	// Create full file path using filepath.Join for safety
-	filePath := filepath.Join(cwd, filepath.Base(filename))
+	filePath := filepath.Join(em.basePath, filepath.Base(filename))
 
 	// Check if file exists
 	if _, err := os.Stat(filePath); err == nil {

--- a/internal/export/png.go
+++ b/internal/export/png.go
@@ -57,6 +57,16 @@ func DefaultPNGOptions() PNGOptions {
 	}
 }
 
+// TerminalAspectRatioPNGOptions returns PNG options that match terminal character
+// aspect ratio. Terminal characters are typically ~2:1 (height:width), so each
+// character cell is rendered twice as tall as it is wide.
+func TerminalAspectRatioPNGOptions() PNGOptions {
+	return PNGOptions{
+		CellWidth:  16, // 16 pixels wide (4x scale)
+		CellHeight: 32, // 32 pixels tall (2:1 height:width ratio)
+	}
+}
+
 // GeneratePNG creates a PNG image from rendered ANSI lines.
 // Returns PNG data as bytes or error.
 func GeneratePNG(lines []string, options PNGOptions) ([]byte, error) {

--- a/internal/export/png.go
+++ b/internal/export/png.go
@@ -1,0 +1,230 @@
+// ABOUTME: PNG generator that converts ANSI-colored text to PNG images.
+// ABOUTME: Parses ANSI escape sequences and renders characters at 16x scale with transparency.
+
+package export
+
+import (
+	"bytes"
+	"fmt"
+	"image"
+	"image/color"
+	"image/png"
+	"regexp"
+	"strconv"
+	"unicode/utf8"
+)
+
+// CellSize defines the default pixel dimensions per terminal character cell.
+// 4x scale per dimension = 16x16 pixels per cell.
+const CellSize = 16
+
+// Unicode block characters
+const (
+	FullBlock       = '█' // U+2588
+	UpperHalfBlock  = '▀' // U+2580
+	LowerHalfBlock  = '▄' // U+2584
+	LightShade      = '░' // U+2591
+	MediumShade     = '▒' // U+2592
+	DarkShade       = '▓' // U+2593
+)
+
+// Alpha values for shade characters (out of 255)
+const (
+	LightShadeAlpha  = 64  // ~25%
+	MediumShadeAlpha = 128 // ~50%
+	DarkShadeAlpha   = 191 // ~75%
+)
+
+// Regex patterns for parsing ANSI escape sequences
+var (
+	// Matches 24-bit foreground color: ESC[38;2;R;G;Bm
+	colorRegex = regexp.MustCompile(`\x1b\[38;2;(\d+);(\d+);(\d+)m`)
+	// Matches any ANSI escape sequence (for stripping)
+	ansiStripRegex = regexp.MustCompile(`\x1b\[[0-9;]*m`)
+)
+
+// PNGOptions contains configuration for PNG generation
+type PNGOptions struct {
+	CellWidth  int // Pixels per character cell width (default: CellSize)
+	CellHeight int // Pixels per character cell height (default: CellSize)
+}
+
+// DefaultPNGOptions returns default PNG generation options (16x16 per cell)
+func DefaultPNGOptions() PNGOptions {
+	return PNGOptions{
+		CellWidth:  CellSize,
+		CellHeight: CellSize,
+	}
+}
+
+// GeneratePNG creates a PNG image from rendered ANSI lines.
+// Returns PNG data as bytes or error.
+func GeneratePNG(lines []string, options PNGOptions) ([]byte, error) {
+	if len(lines) == 0 {
+		return nil, fmt.Errorf("no content to export")
+	}
+
+	// Use defaults if zero values provided
+	if options.CellWidth == 0 {
+		options.CellWidth = CellSize
+	}
+	if options.CellHeight == 0 {
+		options.CellHeight = CellSize
+	}
+
+	// Calculate image dimensions based on max line width
+	maxWidth := 0
+	for _, line := range lines {
+		lineWidth := countVisibleChars(line)
+		if lineWidth > maxWidth {
+			maxWidth = lineWidth
+		}
+	}
+
+	// Handle edge case of all-empty lines
+	if maxWidth == 0 {
+		maxWidth = 1
+	}
+
+	imgWidth := maxWidth * options.CellWidth
+	imgHeight := len(lines) * options.CellHeight
+
+	// Create RGBA image with transparent background (zero-initialized = transparent)
+	img := image.NewRGBA(image.Rect(0, 0, imgWidth, imgHeight))
+
+	// Render each line
+	for lineIdx, line := range lines {
+		renderLineToImage(img, line, lineIdx, options)
+	}
+
+	// Encode to PNG
+	var buf bytes.Buffer
+	if err := png.Encode(&buf, img); err != nil {
+		return nil, fmt.Errorf("failed to encode PNG: %v", err)
+	}
+
+	return buf.Bytes(), nil
+}
+
+// renderLineToImage renders a single line of ANSI text to the image
+func renderLineToImage(img *image.RGBA, line string, lineIdx int, options PNGOptions) {
+	// Default color (white, fully opaque)
+	currentColor := color.RGBA{R: 255, G: 255, B: 255, A: 255}
+	charIdx := 0
+
+	// Process line character by character, tracking ANSI state
+	i := 0
+	lineBytes := []byte(line)
+
+	for i < len(lineBytes) {
+		// Check for ANSI escape sequence (starts with ESC [)
+		if lineBytes[i] == 0x1b && i+1 < len(lineBytes) && lineBytes[i+1] == '[' {
+			// Find end of escape sequence
+			seqStart := i
+			i += 2 // Skip ESC [
+
+			// Scan for terminator (letter)
+			for i < len(lineBytes) && !isAnsiTerminator(lineBytes[i]) {
+				i++
+			}
+			if i < len(lineBytes) {
+				i++ // Include terminator
+			}
+
+			// Parse the sequence
+			seq := string(lineBytes[seqStart:i])
+			if matches := colorRegex.FindStringSubmatch(seq); matches != nil {
+				r, _ := strconv.Atoi(matches[1])
+				g, _ := strconv.Atoi(matches[2])
+				b, _ := strconv.Atoi(matches[3])
+				currentColor = color.RGBA{R: uint8(r), G: uint8(g), B: uint8(b), A: 255}
+			}
+			// Reset codes (\x1b[0m) are handled implicitly - color stays until changed
+			continue
+		}
+
+		// Decode UTF-8 character
+		r, size := utf8.DecodeRune(lineBytes[i:])
+		if r == utf8.RuneError && size == 1 {
+			// Invalid UTF-8, skip byte
+			i++
+			continue
+		}
+
+		// Render the character
+		drawCell(img, charIdx, lineIdx, r, currentColor, options)
+		charIdx++
+		i += size
+	}
+}
+
+// drawCell draws a single character cell to the image
+func drawCell(img *image.RGBA, x, y int, char rune, c color.RGBA, options PNGOptions) {
+	cellX := x * options.CellWidth
+	cellY := y * options.CellHeight
+	halfHeight := options.CellHeight / 2
+
+	switch char {
+	case FullBlock:
+		// Fill entire cell
+		fillRect(img, cellX, cellY, options.CellWidth, options.CellHeight, c)
+
+	case UpperHalfBlock:
+		// Fill top half only
+		fillRect(img, cellX, cellY, options.CellWidth, halfHeight, c)
+
+	case LowerHalfBlock:
+		// Fill bottom half only
+		fillRect(img, cellX, cellY+halfHeight, options.CellWidth, halfHeight, c)
+
+	case LightShade:
+		// Full cell with low alpha
+		shadeColor := color.RGBA{R: c.R, G: c.G, B: c.B, A: LightShadeAlpha}
+		fillRect(img, cellX, cellY, options.CellWidth, options.CellHeight, shadeColor)
+
+	case MediumShade:
+		// Full cell with medium alpha
+		shadeColor := color.RGBA{R: c.R, G: c.G, B: c.B, A: MediumShadeAlpha}
+		fillRect(img, cellX, cellY, options.CellWidth, options.CellHeight, shadeColor)
+
+	case DarkShade:
+		// Full cell with high alpha
+		shadeColor := color.RGBA{R: c.R, G: c.G, B: c.B, A: DarkShadeAlpha}
+		fillRect(img, cellX, cellY, options.CellWidth, options.CellHeight, shadeColor)
+
+	case ' ':
+		// Space - leave transparent (do nothing)
+
+	default:
+		// For any other printable character, fill as full block
+		// This handles edge cases where other characters might be used
+		if char > 32 { // Printable ASCII/Unicode
+			fillRect(img, cellX, cellY, options.CellWidth, options.CellHeight, c)
+		}
+		// Non-printable or control chars: leave transparent
+	}
+}
+
+// fillRect fills a rectangle in the image with the given color
+func fillRect(img *image.RGBA, x, y, width, height int, c color.RGBA) {
+	bounds := img.Bounds()
+	for dy := 0; dy < height; dy++ {
+		for dx := 0; dx < width; dx++ {
+			px, py := x+dx, y+dy
+			if px >= bounds.Min.X && px < bounds.Max.X && py >= bounds.Min.Y && py < bounds.Max.Y {
+				img.SetRGBA(px, py, c)
+			}
+		}
+	}
+}
+
+// countVisibleChars counts visible (non-ANSI) characters in a line
+func countVisibleChars(line string) int {
+	stripped := ansiStripRegex.ReplaceAllString(line, "")
+	return utf8.RuneCountInString(stripped)
+}
+
+// isAnsiTerminator checks if a byte terminates an ANSI escape sequence
+func isAnsiTerminator(b byte) bool {
+	return (b >= 'A' && b <= 'Z') || (b >= 'a' && b <= 'z')
+}

--- a/internal/export/png_test.go
+++ b/internal/export/png_test.go
@@ -1,0 +1,314 @@
+// ABOUTME: Tests for PNG generation from ANSI-colored text output.
+// ABOUTME: Verifies correct parsing of ANSI codes and pixel rendering at 16x scale.
+
+package export
+
+import (
+	"bytes"
+	"image"
+	"image/png"
+	"testing"
+)
+
+func TestGeneratePNG_EmptyInput(t *testing.T) {
+	_, err := GeneratePNG([]string{}, DefaultPNGOptions())
+	if err == nil {
+		t.Error("expected error for empty input, got nil")
+	}
+}
+
+func TestGeneratePNG_NilInput(t *testing.T) {
+	_, err := GeneratePNG(nil, DefaultPNGOptions())
+	if err == nil {
+		t.Error("expected error for nil input, got nil")
+	}
+}
+
+func TestGeneratePNG_OnlySpaces(t *testing.T) {
+	// A line with only spaces should produce a valid (but transparent) PNG
+	lines := []string{"   "}
+	data, err := GeneratePNG(lines, DefaultPNGOptions())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Should still produce valid PNG
+	if !bytes.HasPrefix(data, []byte{0x89, 'P', 'N', 'G'}) {
+		t.Error("invalid PNG header")
+	}
+}
+
+func TestGeneratePNG_ValidPNGHeader(t *testing.T) {
+	// Simple red full block character
+	lines := []string{"\x1b[38;2;255;0;0m█\x1b[0m"}
+
+	data, err := GeneratePNG(lines, DefaultPNGOptions())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Verify PNG magic bytes
+	if !bytes.HasPrefix(data, []byte{0x89, 'P', 'N', 'G'}) {
+		t.Error("invalid PNG header - missing PNG magic bytes")
+	}
+}
+
+func TestGeneratePNG_SingleCharDimensions(t *testing.T) {
+	// One character should produce 16x16 pixels
+	lines := []string{"\x1b[38;2;255;0;0m█\x1b[0m"}
+
+	data, err := GeneratePNG(lines, DefaultPNGOptions())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	img, err := png.Decode(bytes.NewReader(data))
+	if err != nil {
+		t.Fatalf("failed to decode PNG: %v", err)
+	}
+
+	bounds := img.Bounds()
+	if bounds.Dx() != CellSize || bounds.Dy() != CellSize {
+		t.Errorf("expected %dx%d, got %dx%d", CellSize, CellSize, bounds.Dx(), bounds.Dy())
+	}
+}
+
+func TestGeneratePNG_MultipleCharDimensions(t *testing.T) {
+	// Three characters on one line should produce 48x16 pixels
+	lines := []string{"\x1b[38;2;255;0;0m███\x1b[0m"}
+
+	data, err := GeneratePNG(lines, DefaultPNGOptions())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	img, err := png.Decode(bytes.NewReader(data))
+	if err != nil {
+		t.Fatalf("failed to decode PNG: %v", err)
+	}
+
+	bounds := img.Bounds()
+	expectedWidth := 3 * CellSize
+	if bounds.Dx() != expectedWidth || bounds.Dy() != CellSize {
+		t.Errorf("expected %dx%d, got %dx%d", expectedWidth, CellSize, bounds.Dx(), bounds.Dy())
+	}
+}
+
+func TestGeneratePNG_MultipleLinesimensions(t *testing.T) {
+	// Two lines of one character each should produce 16x32 pixels
+	lines := []string{
+		"\x1b[38;2;255;0;0m█\x1b[0m",
+		"\x1b[38;2;0;255;0m█\x1b[0m",
+	}
+
+	data, err := GeneratePNG(lines, DefaultPNGOptions())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	img, err := png.Decode(bytes.NewReader(data))
+	if err != nil {
+		t.Fatalf("failed to decode PNG: %v", err)
+	}
+
+	bounds := img.Bounds()
+	expectedHeight := 2 * CellSize
+	if bounds.Dx() != CellSize || bounds.Dy() != expectedHeight {
+		t.Errorf("expected %dx%d, got %dx%d", CellSize, expectedHeight, bounds.Dx(), bounds.Dy())
+	}
+}
+
+func TestGeneratePNG_TransparentBackground(t *testing.T) {
+	// Space character should result in transparent pixel
+	lines := []string{" "}
+
+	data, err := GeneratePNG(lines, DefaultPNGOptions())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	img, err := png.Decode(bytes.NewReader(data))
+	if err != nil {
+		t.Fatalf("failed to decode PNG: %v", err)
+	}
+
+	// Check center pixel is transparent
+	rgba, ok := img.(*image.NRGBA)
+	if !ok {
+		// Try RGBA
+		rgbaImg, ok := img.(*image.RGBA)
+		if !ok {
+			t.Fatalf("unexpected image type: %T", img)
+		}
+		pixel := rgbaImg.RGBAAt(CellSize/2, CellSize/2)
+		if pixel.A != 0 {
+			t.Errorf("expected transparent pixel (A=0), got A=%d", pixel.A)
+		}
+		return
+	}
+	pixel := rgba.NRGBAAt(CellSize/2, CellSize/2)
+	if pixel.A != 0 {
+		t.Errorf("expected transparent pixel (A=0), got A=%d", pixel.A)
+	}
+}
+
+func TestGeneratePNG_ColorParsing(t *testing.T) {
+	// Red full block
+	lines := []string{"\x1b[38;2;255;0;0m█\x1b[0m"}
+
+	data, err := GeneratePNG(lines, DefaultPNGOptions())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	img, err := png.Decode(bytes.NewReader(data))
+	if err != nil {
+		t.Fatalf("failed to decode PNG: %v", err)
+	}
+
+	// Check center pixel is red
+	r, g, b, a := img.At(CellSize/2, CellSize/2).RGBA()
+	// RGBA returns values in [0, 65535] range
+	r8, g8, b8, a8 := uint8(r>>8), uint8(g>>8), uint8(b>>8), uint8(a>>8)
+
+	if r8 != 255 || g8 != 0 || b8 != 0 {
+		t.Errorf("expected red pixel (255,0,0), got (%d,%d,%d)", r8, g8, b8)
+	}
+	if a8 != 255 {
+		t.Errorf("expected opaque pixel (A=255), got A=%d", a8)
+	}
+}
+
+func TestGeneratePNG_UpperHalfBlock(t *testing.T) {
+	// Upper half block should only fill top 8 rows
+	lines := []string{"\x1b[38;2;0;255;0m▀\x1b[0m"}
+
+	data, err := GeneratePNG(lines, DefaultPNGOptions())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	img, err := png.Decode(bytes.NewReader(data))
+	if err != nil {
+		t.Fatalf("failed to decode PNG: %v", err)
+	}
+
+	// Top half should be green (row 4)
+	_, _, _, topA := img.At(CellSize/2, CellSize/4).RGBA()
+	if uint8(topA>>8) == 0 {
+		t.Error("expected top half to be opaque, got transparent")
+	}
+
+	// Bottom half should be transparent (row 12)
+	_, _, _, bottomA := img.At(CellSize/2, CellSize*3/4).RGBA()
+	if uint8(bottomA>>8) != 0 {
+		t.Errorf("expected bottom half to be transparent, got A=%d", uint8(bottomA>>8))
+	}
+}
+
+func TestGeneratePNG_LowerHalfBlock(t *testing.T) {
+	// Lower half block should only fill bottom 8 rows
+	lines := []string{"\x1b[38;2;0;0;255m▄\x1b[0m"}
+
+	data, err := GeneratePNG(lines, DefaultPNGOptions())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	img, err := png.Decode(bytes.NewReader(data))
+	if err != nil {
+		t.Fatalf("failed to decode PNG: %v", err)
+	}
+
+	// Top half should be transparent (row 4)
+	_, _, _, topA := img.At(CellSize/2, CellSize/4).RGBA()
+	if uint8(topA>>8) != 0 {
+		t.Errorf("expected top half to be transparent, got A=%d", uint8(topA>>8))
+	}
+
+	// Bottom half should be blue (row 12)
+	_, _, _, bottomA := img.At(CellSize/2, CellSize*3/4).RGBA()
+	if uint8(bottomA>>8) == 0 {
+		t.Error("expected bottom half to be opaque, got transparent")
+	}
+}
+
+func TestGeneratePNG_ShadeCharacterLightShade(t *testing.T) {
+	// Light shade (░) should have low alpha
+	lines := []string{"\x1b[38;2;255;255;255m░\x1b[0m"}
+
+	data, err := GeneratePNG(lines, DefaultPNGOptions())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	img, err := png.Decode(bytes.NewReader(data))
+	if err != nil {
+		t.Fatalf("failed to decode PNG: %v", err)
+	}
+
+	_, _, _, a := img.At(CellSize/2, CellSize/2).RGBA()
+	alpha := uint8(a >> 8)
+	// Light shade should have alpha around 64 (25%)
+	if alpha < 32 || alpha > 96 {
+		t.Errorf("expected light shade alpha ~64, got %d", alpha)
+	}
+}
+
+func TestGeneratePNG_CustomCellSize(t *testing.T) {
+	lines := []string{"\x1b[38;2;255;0;0m█\x1b[0m"}
+
+	opts := PNGOptions{
+		CellWidth:  8,
+		CellHeight: 8,
+	}
+	data, err := GeneratePNG(lines, opts)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	img, err := png.Decode(bytes.NewReader(data))
+	if err != nil {
+		t.Fatalf("failed to decode PNG: %v", err)
+	}
+
+	bounds := img.Bounds()
+	if bounds.Dx() != 8 || bounds.Dy() != 8 {
+		t.Errorf("expected 8x8 with custom options, got %dx%d", bounds.Dx(), bounds.Dy())
+	}
+}
+
+func TestDefaultPNGOptions(t *testing.T) {
+	opts := DefaultPNGOptions()
+
+	if opts.CellWidth != CellSize {
+		t.Errorf("expected default CellWidth=%d, got %d", CellSize, opts.CellWidth)
+	}
+	if opts.CellHeight != CellSize {
+		t.Errorf("expected default CellHeight=%d, got %d", CellSize, opts.CellHeight)
+	}
+}
+
+func TestCountVisibleChars(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected int
+	}{
+		{"plain text", "hello", 5},
+		{"with ANSI color", "\x1b[38;2;255;0;0mhello\x1b[0m", 5},
+		{"only ANSI codes", "\x1b[38;2;255;0;0m\x1b[0m", 0},
+		{"mixed", "\x1b[38;2;255;0;0ma\x1b[0mb", 2},
+		{"empty", "", 0},
+		{"unicode blocks", "█▀▄", 3},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := countVisibleChars(tt.input)
+			if got != tt.expected {
+				t.Errorf("countVisibleChars(%q) = %d, want %d", tt.input, got, tt.expected)
+			}
+		})
+	}
+}

--- a/internal/export/types.go
+++ b/internal/export/types.go
@@ -1,10 +1,14 @@
 package export
 
+// ABOUTME: Defines export format types and the list of supported export formats.
+// ABOUTME: Includes text formats (TXT, GO, JS, PY, RS, SH) and binary formats (PNG).
+
 // ExportFormat represents a supported export format
 type ExportFormat struct {
-	Name        string // Canonical key (e.g., "TXT")
+	Name        string // Canonical key (e.g., "TXT", "PNG")
 	Extension   string
 	Description string
+	IsBinary    bool // True for binary formats like PNG that need []byte handling
 }
 
 // Available export formats
@@ -38,5 +42,11 @@ var SupportedFormats = []ExportFormat{
 		Name:        "SH",
 		Extension:   ".sh",
 		Description: "Bash script",
+	},
+	{
+		Name:        "PNG",
+		Extension:   ".png",
+		Description: "PNG image (16x scale, transparent)",
+		IsBinary:    true,
 	},
 }

--- a/internal/export/types.go
+++ b/internal/export/types.go
@@ -14,6 +14,12 @@ type ExportFormat struct {
 // Available export formats
 var SupportedFormats = []ExportFormat{
 	{
+		Name:        "PNG",
+		Extension:   ".png",
+		Description: "PNG image (transparent background)",
+		IsBinary:    true,
+	},
+	{
 		Name:        "TXT",
 		Extension:   ".txt",
 		Description: "Plain text file",
@@ -42,11 +48,5 @@ var SupportedFormats = []ExportFormat{
 		Name:        "SH",
 		Extension:   ".sh",
 		Description: "Bash script",
-	},
-	{
-		Name:        "PNG",
-		Extension:   ".png",
-		Description: "PNG image (16x scale, transparent)",
-		IsBinary:    true,
 	},
 }

--- a/internal/favorites/manager.go
+++ b/internal/favorites/manager.go
@@ -1,0 +1,89 @@
+// ABOUTME: Business logic for managing favorites (add, remove, list, get).
+// ABOUTME: Handles ID generation and persists changes to disk.
+
+package favorites
+
+import (
+	"errors"
+	"fmt"
+	"time"
+)
+
+var (
+	ErrNotFound = errors.New("favorite not found")
+)
+
+// Manager handles favorites operations
+type Manager struct {
+	store *FavoritesStore
+}
+
+// NewManager creates a new Manager, loading existing favorites from disk
+func NewManager() (*Manager, error) {
+	store, err := Load()
+	if err != nil {
+		return nil, err
+	}
+	return &Manager{store: store}, nil
+}
+
+// Add adds a new favorite and returns its generated ID
+func (m *Manager) Add(fav Favorite) (string, error) {
+	// Generate unique ID using timestamp
+	fav.ID = fmt.Sprintf("fav_%d", time.Now().UnixNano())
+	fav.CreatedAt = time.Now().UTC()
+
+	m.store.Favorites = append(m.store.Favorites, fav)
+
+	err := Save(m.store)
+	if err != nil {
+		// Rollback on save failure
+		m.store.Favorites = m.store.Favorites[:len(m.store.Favorites)-1]
+		return "", err
+	}
+
+	return fav.ID, nil
+}
+
+// Get returns a favorite by ID
+func (m *Manager) Get(id string) (*Favorite, error) {
+	for i := range m.store.Favorites {
+		if m.store.Favorites[i].ID == id {
+			return &m.store.Favorites[i], nil
+		}
+	}
+	return nil, ErrNotFound
+}
+
+// Remove deletes a favorite by ID
+func (m *Manager) Remove(id string) error {
+	idx := -1
+	for i, fav := range m.store.Favorites {
+		if fav.ID == id {
+			idx = i
+			break
+		}
+	}
+
+	if idx == -1 {
+		return ErrNotFound
+	}
+
+	// Remove by index
+	removed := m.store.Favorites[idx]
+	m.store.Favorites = append(m.store.Favorites[:idx], m.store.Favorites[idx+1:]...)
+
+	err := Save(m.store)
+	if err != nil {
+		// Rollback on save failure
+		m.store.Favorites = append(m.store.Favorites[:idx], append([]Favorite{removed}, m.store.Favorites[idx:]...)...)
+		return err
+	}
+
+	return nil
+}
+
+// List returns all favorites
+func (m *Manager) List() []Favorite {
+	return m.store.Favorites
+}

--- a/internal/favorites/manager_test.go
+++ b/internal/favorites/manager_test.go
@@ -1,0 +1,244 @@
+// ABOUTME: Tests for favorites manager business logic.
+// ABOUTME: Validates add, remove, list, and get operations.
+
+package favorites
+
+import (
+	"os"
+	"testing"
+)
+
+func setupTestEnv(t *testing.T) func() {
+	tmpHome := t.TempDir()
+	originalHome := os.Getenv("HOME")
+	os.Setenv("HOME", tmpHome)
+	return func() {
+		os.Setenv("HOME", originalHome)
+	}
+}
+
+func TestNewManager_LoadsExistingFavorites(t *testing.T) {
+	cleanup := setupTestEnv(t)
+	defer cleanup()
+
+	// Pre-save some favorites
+	store := &FavoritesStore{
+		Favorites: []Favorite{
+			{ID: "existing-1", Name: "Existing"},
+		},
+	}
+	err := Save(store)
+	if err != nil {
+		t.Fatalf("failed to save initial store: %v", err)
+	}
+
+	// Create manager - should load existing
+	mgr, err := NewManager()
+	if err != nil {
+		t.Fatalf("NewManager failed: %v", err)
+	}
+
+	favorites := mgr.List()
+	if len(favorites) != 1 {
+		t.Errorf("expected 1 favorite, got %d", len(favorites))
+	}
+}
+
+func TestManager_Add(t *testing.T) {
+	cleanup := setupTestEnv(t)
+	defer cleanup()
+
+	mgr, err := NewManager()
+	if err != nil {
+		t.Fatalf("NewManager failed: %v", err)
+	}
+
+	fav := Favorite{
+		Name:     "Test Art",
+		Text:     "Hello",
+		FontName: "BlockFont",
+	}
+
+	id, err := mgr.Add(fav)
+	if err != nil {
+		t.Fatalf("Add failed: %v", err)
+	}
+
+	if id == "" {
+		t.Error("Add should return non-empty ID")
+	}
+
+	// Verify it's in the list
+	favorites := mgr.List()
+	if len(favorites) != 1 {
+		t.Fatalf("expected 1 favorite, got %d", len(favorites))
+	}
+
+	if favorites[0].ID != id {
+		t.Errorf("ID mismatch: got %q, want %q", favorites[0].ID, id)
+	}
+	if favorites[0].Name != "Test Art" {
+		t.Errorf("Name mismatch: got %q", favorites[0].Name)
+	}
+}
+
+func TestManager_Add_PersistsToDisk(t *testing.T) {
+	cleanup := setupTestEnv(t)
+	defer cleanup()
+
+	mgr, err := NewManager()
+	if err != nil {
+		t.Fatalf("NewManager failed: %v", err)
+	}
+
+	_, err = mgr.Add(Favorite{Name: "Persisted", Text: "Test"})
+	if err != nil {
+		t.Fatalf("Add failed: %v", err)
+	}
+
+	// Create new manager - should load persisted favorite
+	mgr2, err := NewManager()
+	if err != nil {
+		t.Fatalf("NewManager failed: %v", err)
+	}
+
+	favorites := mgr2.List()
+	if len(favorites) != 1 {
+		t.Fatalf("expected 1 persisted favorite, got %d", len(favorites))
+	}
+	if favorites[0].Name != "Persisted" {
+		t.Errorf("Name mismatch: got %q", favorites[0].Name)
+	}
+}
+
+func TestManager_Get(t *testing.T) {
+	cleanup := setupTestEnv(t)
+	defer cleanup()
+
+	mgr, err := NewManager()
+	if err != nil {
+		t.Fatalf("NewManager failed: %v", err)
+	}
+
+	id, err := mgr.Add(Favorite{Name: "GetTest", Text: "Hello"})
+	if err != nil {
+		t.Fatalf("Add failed: %v", err)
+	}
+
+	fav, err := mgr.Get(id)
+	if err != nil {
+		t.Fatalf("Get failed: %v", err)
+	}
+
+	if fav.Name != "GetTest" {
+		t.Errorf("Name mismatch: got %q", fav.Name)
+	}
+}
+
+func TestManager_Get_NotFound(t *testing.T) {
+	cleanup := setupTestEnv(t)
+	defer cleanup()
+
+	mgr, err := NewManager()
+	if err != nil {
+		t.Fatalf("NewManager failed: %v", err)
+	}
+
+	_, err = mgr.Get("nonexistent")
+	if err == nil {
+		t.Error("expected error for nonexistent ID")
+	}
+}
+
+func TestManager_Remove(t *testing.T) {
+	cleanup := setupTestEnv(t)
+	defer cleanup()
+
+	mgr, err := NewManager()
+	if err != nil {
+		t.Fatalf("NewManager failed: %v", err)
+	}
+
+	id, err := mgr.Add(Favorite{Name: "ToRemove"})
+	if err != nil {
+		t.Fatalf("Add failed: %v", err)
+	}
+
+	err = mgr.Remove(id)
+	if err != nil {
+		t.Fatalf("Remove failed: %v", err)
+	}
+
+	favorites := mgr.List()
+	if len(favorites) != 0 {
+		t.Errorf("expected 0 favorites after remove, got %d", len(favorites))
+	}
+}
+
+func TestManager_Remove_NotFound(t *testing.T) {
+	cleanup := setupTestEnv(t)
+	defer cleanup()
+
+	mgr, err := NewManager()
+	if err != nil {
+		t.Fatalf("NewManager failed: %v", err)
+	}
+
+	err = mgr.Remove("nonexistent")
+	if err == nil {
+		t.Error("expected error for removing nonexistent ID")
+	}
+}
+
+func TestManager_Remove_PersistsToDisk(t *testing.T) {
+	cleanup := setupTestEnv(t)
+	defer cleanup()
+
+	mgr, err := NewManager()
+	if err != nil {
+		t.Fatalf("NewManager failed: %v", err)
+	}
+
+	id, _ := mgr.Add(Favorite{Name: "ToRemove"})
+	mgr.Remove(id)
+
+	// Create new manager - should reflect removal
+	mgr2, err := NewManager()
+	if err != nil {
+		t.Fatalf("NewManager failed: %v", err)
+	}
+
+	if len(mgr2.List()) != 0 {
+		t.Error("removal was not persisted")
+	}
+}
+
+func TestManager_List_ReturnsInOrder(t *testing.T) {
+	cleanup := setupTestEnv(t)
+	defer cleanup()
+
+	mgr, err := NewManager()
+	if err != nil {
+		t.Fatalf("NewManager failed: %v", err)
+	}
+
+	mgr.Add(Favorite{Name: "First"})
+	mgr.Add(Favorite{Name: "Second"})
+	mgr.Add(Favorite{Name: "Third"})
+
+	favorites := mgr.List()
+	if len(favorites) != 3 {
+		t.Fatalf("expected 3 favorites, got %d", len(favorites))
+	}
+
+	// Should be in insertion order
+	if favorites[0].Name != "First" {
+		t.Errorf("expected First, got %q", favorites[0].Name)
+	}
+	if favorites[1].Name != "Second" {
+		t.Errorf("expected Second, got %q", favorites[1].Name)
+	}
+	if favorites[2].Name != "Third" {
+		t.Errorf("expected Third, got %q", favorites[2].Name)
+	}
+}

--- a/internal/favorites/storage.go
+++ b/internal/favorites/storage.go
@@ -1,0 +1,86 @@
+// ABOUTME: File I/O operations for favorites persistence.
+// ABOUTME: Handles reading/writing favorites.json in ~/.config/bit/.
+
+package favorites
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+)
+
+const (
+	configDirName     = "bit"
+	favoritesFileName = "favorites.json"
+)
+
+// GetConfigDir returns the config directory path, creating it if needed.
+// Uses ~/.config/bit/ following XDG conventions.
+func GetConfigDir() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+
+	configDir := filepath.Join(home, ".config", configDirName)
+	err = os.MkdirAll(configDir, 0755)
+	if err != nil {
+		return "", err
+	}
+
+	return configDir, nil
+}
+
+// GetFavoritesFilePath returns the full path to favorites.json
+func GetFavoritesFilePath() (string, error) {
+	configDir, err := GetConfigDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(configDir, favoritesFileName), nil
+}
+
+// Load reads favorites from disk. Returns empty store if file doesn't exist.
+func Load() (*FavoritesStore, error) {
+	filePath, err := GetFavoritesFilePath()
+	if err != nil {
+		return nil, err
+	}
+
+	data, err := os.ReadFile(filePath)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return &FavoritesStore{Favorites: []Favorite{}}, nil
+		}
+		return nil, err
+	}
+
+	var store FavoritesStore
+	err = json.Unmarshal(data, &store)
+	if err != nil {
+		return nil, err
+	}
+
+	// Ensure Favorites is never nil
+	if store.Favorites == nil {
+		store.Favorites = []Favorite{}
+	}
+
+	return &store, nil
+}
+
+// Save writes favorites to disk
+func Save(store *FavoritesStore) error {
+	filePath, err := GetFavoritesFilePath()
+	if err != nil {
+		return err
+	}
+
+	data, err := json.MarshalIndent(store, "", "  ")
+	if err != nil {
+		return err
+	}
+
+	return os.WriteFile(filePath, data, 0644)
+}

--- a/internal/favorites/storage_test.go
+++ b/internal/favorites/storage_test.go
@@ -1,0 +1,146 @@
+// ABOUTME: Tests for favorites file storage operations.
+// ABOUTME: Validates loading, saving, and config directory handling.
+
+package favorites
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestGetConfigDir_CreatesDirectory(t *testing.T) {
+	// Use temp dir as home
+	tmpHome := t.TempDir()
+	originalHome := os.Getenv("HOME")
+	os.Setenv("HOME", tmpHome)
+	defer os.Setenv("HOME", originalHome)
+
+	dir, err := GetConfigDir()
+	if err != nil {
+		t.Fatalf("GetConfigDir failed: %v", err)
+	}
+
+	expectedDir := filepath.Join(tmpHome, ".config", "bit")
+	if dir != expectedDir {
+		t.Errorf("unexpected dir: got %q, want %q", dir, expectedDir)
+	}
+
+	// Verify directory exists
+	info, err := os.Stat(dir)
+	if err != nil {
+		t.Fatalf("config dir does not exist: %v", err)
+	}
+	if !info.IsDir() {
+		t.Error("config path is not a directory")
+	}
+}
+
+func TestLoad_MissingFile_ReturnsEmptyStore(t *testing.T) {
+	tmpHome := t.TempDir()
+	originalHome := os.Getenv("HOME")
+	os.Setenv("HOME", tmpHome)
+	defer os.Setenv("HOME", originalHome)
+
+	store, err := Load()
+	if err != nil {
+		t.Fatalf("Load failed: %v", err)
+	}
+
+	if store.Favorites == nil {
+		t.Error("Favorites should not be nil")
+	}
+	if len(store.Favorites) != 0 {
+		t.Errorf("expected empty favorites, got %d", len(store.Favorites))
+	}
+}
+
+func TestSaveAndLoad_RoundTrip(t *testing.T) {
+	tmpHome := t.TempDir()
+	originalHome := os.Getenv("HOME")
+	os.Setenv("HOME", tmpHome)
+	defer os.Setenv("HOME", originalHome)
+
+	original := &FavoritesStore{
+		Favorites: []Favorite{
+			{
+				ID:          "test-1",
+				Name:        "Test Favorite",
+				CreatedAt:   time.Now().UTC().Truncate(time.Second),
+				Text:        "Hello World",
+				FontName:    "BlockFont",
+				CharSpacing: 2,
+			},
+		},
+	}
+
+	// Save
+	err := Save(original)
+	if err != nil {
+		t.Fatalf("Save failed: %v", err)
+	}
+
+	// Load
+	loaded, err := Load()
+	if err != nil {
+		t.Fatalf("Load failed: %v", err)
+	}
+
+	if len(loaded.Favorites) != 1 {
+		t.Fatalf("expected 1 favorite, got %d", len(loaded.Favorites))
+	}
+
+	fav := loaded.Favorites[0]
+	if fav.ID != "test-1" {
+		t.Errorf("ID mismatch: got %q", fav.ID)
+	}
+	if fav.Name != "Test Favorite" {
+		t.Errorf("Name mismatch: got %q", fav.Name)
+	}
+	if fav.Text != "Hello World" {
+		t.Errorf("Text mismatch: got %q", fav.Text)
+	}
+}
+
+func TestLoad_InvalidJSON_ReturnsError(t *testing.T) {
+	tmpHome := t.TempDir()
+	originalHome := os.Getenv("HOME")
+	os.Setenv("HOME", tmpHome)
+	defer os.Setenv("HOME", originalHome)
+
+	// Create config dir and write invalid JSON
+	configDir := filepath.Join(tmpHome, ".config", "bit")
+	err := os.MkdirAll(configDir, 0755)
+	if err != nil {
+		t.Fatalf("failed to create config dir: %v", err)
+	}
+
+	filePath := filepath.Join(configDir, "favorites.json")
+	err = os.WriteFile(filePath, []byte("not valid json{"), 0644)
+	if err != nil {
+		t.Fatalf("failed to write invalid json: %v", err)
+	}
+
+	_, err = Load()
+	if err == nil {
+		t.Error("expected error for invalid JSON, got nil")
+	}
+}
+
+func TestGetFavoritesFilePath(t *testing.T) {
+	tmpHome := t.TempDir()
+	originalHome := os.Getenv("HOME")
+	os.Setenv("HOME", tmpHome)
+	defer os.Setenv("HOME", originalHome)
+
+	path, err := GetFavoritesFilePath()
+	if err != nil {
+		t.Fatalf("GetFavoritesFilePath failed: %v", err)
+	}
+
+	expected := filepath.Join(tmpHome, ".config", "bit", "favorites.json")
+	if path != expected {
+		t.Errorf("path mismatch: got %q, want %q", path, expected)
+	}
+}

--- a/internal/favorites/types.go
+++ b/internal/favorites/types.go
@@ -1,0 +1,43 @@
+// ABOUTME: Type definitions for the favorites persistence system.
+// ABOUTME: Contains Favorite struct with all ASCII art configuration fields.
+
+package favorites
+
+import "time"
+
+// Favorite represents a saved ASCII art configuration
+type Favorite struct {
+	ID        string    `json:"id"`
+	Name      string    `json:"name"`
+	CreatedAt time.Time `json:"created_at"`
+
+	// Text content
+	Text      string `json:"text"`
+	FontName  string `json:"font_name"`
+	Alignment int    `json:"alignment"`
+
+	// Spacing
+	CharSpacing int `json:"char_spacing"`
+	WordSpacing int `json:"word_spacing"`
+	LineSpacing int `json:"line_spacing"`
+
+	// Color
+	TextColor         int  `json:"text_color"`
+	GradientEnabled   bool `json:"gradient_enabled"`
+	GradientColor     int  `json:"gradient_color"`
+	GradientDirection int  `json:"gradient_direction"`
+
+	// Scale
+	Scale int `json:"scale"`
+
+	// Shadow
+	ShadowEnabled bool `json:"shadow_enabled"`
+	ShadowHOffset int  `json:"shadow_h_offset"`
+	ShadowVOffset int  `json:"shadow_v_offset"`
+	ShadowStyle   int  `json:"shadow_style"`
+}
+
+// FavoritesStore holds all saved favorites
+type FavoritesStore struct {
+	Favorites []Favorite `json:"favorites"`
+}

--- a/internal/favorites/types_test.go
+++ b/internal/favorites/types_test.go
@@ -1,0 +1,162 @@
+// ABOUTME: Tests for favorites type definitions and JSON serialization.
+// ABOUTME: Validates Favorite struct fields and round-trip JSON encoding/decoding.
+
+package favorites
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+func TestFavorite_JSONRoundTrip(t *testing.T) {
+	original := Favorite{
+		ID:        "test-123",
+		Name:      "My Cool Art",
+		CreatedAt: time.Date(2024, 1, 15, 10, 30, 0, 0, time.UTC),
+
+		Text:      "Hello\nWorld",
+		FontName:  "BlockFont",
+		Alignment: 1,
+
+		CharSpacing: 2,
+		WordSpacing: 4,
+		LineSpacing: 1,
+
+		TextColor:         3,
+		GradientEnabled:   true,
+		GradientColor:     5,
+		GradientDirection: 2,
+
+		Scale: 1,
+
+		ShadowEnabled: true,
+		ShadowHOffset: 2,
+		ShadowVOffset: -1,
+		ShadowStyle:   1,
+	}
+
+	// Marshal to JSON
+	data, err := json.Marshal(original)
+	if err != nil {
+		t.Fatalf("failed to marshal Favorite: %v", err)
+	}
+
+	// Unmarshal back
+	var decoded Favorite
+	err = json.Unmarshal(data, &decoded)
+	if err != nil {
+		t.Fatalf("failed to unmarshal Favorite: %v", err)
+	}
+
+	// Verify all fields
+	if decoded.ID != original.ID {
+		t.Errorf("ID mismatch: got %q, want %q", decoded.ID, original.ID)
+	}
+	if decoded.Name != original.Name {
+		t.Errorf("Name mismatch: got %q, want %q", decoded.Name, original.Name)
+	}
+	if !decoded.CreatedAt.Equal(original.CreatedAt) {
+		t.Errorf("CreatedAt mismatch: got %v, want %v", decoded.CreatedAt, original.CreatedAt)
+	}
+	if decoded.Text != original.Text {
+		t.Errorf("Text mismatch: got %q, want %q", decoded.Text, original.Text)
+	}
+	if decoded.FontName != original.FontName {
+		t.Errorf("FontName mismatch: got %q, want %q", decoded.FontName, original.FontName)
+	}
+	if decoded.Alignment != original.Alignment {
+		t.Errorf("Alignment mismatch: got %d, want %d", decoded.Alignment, original.Alignment)
+	}
+	if decoded.CharSpacing != original.CharSpacing {
+		t.Errorf("CharSpacing mismatch: got %d, want %d", decoded.CharSpacing, original.CharSpacing)
+	}
+	if decoded.WordSpacing != original.WordSpacing {
+		t.Errorf("WordSpacing mismatch: got %d, want %d", decoded.WordSpacing, original.WordSpacing)
+	}
+	if decoded.LineSpacing != original.LineSpacing {
+		t.Errorf("LineSpacing mismatch: got %d, want %d", decoded.LineSpacing, original.LineSpacing)
+	}
+	if decoded.TextColor != original.TextColor {
+		t.Errorf("TextColor mismatch: got %d, want %d", decoded.TextColor, original.TextColor)
+	}
+	if decoded.GradientEnabled != original.GradientEnabled {
+		t.Errorf("GradientEnabled mismatch: got %v, want %v", decoded.GradientEnabled, original.GradientEnabled)
+	}
+	if decoded.GradientColor != original.GradientColor {
+		t.Errorf("GradientColor mismatch: got %d, want %d", decoded.GradientColor, original.GradientColor)
+	}
+	if decoded.GradientDirection != original.GradientDirection {
+		t.Errorf("GradientDirection mismatch: got %d, want %d", decoded.GradientDirection, original.GradientDirection)
+	}
+	if decoded.Scale != original.Scale {
+		t.Errorf("Scale mismatch: got %d, want %d", decoded.Scale, original.Scale)
+	}
+	if decoded.ShadowEnabled != original.ShadowEnabled {
+		t.Errorf("ShadowEnabled mismatch: got %v, want %v", decoded.ShadowEnabled, original.ShadowEnabled)
+	}
+	if decoded.ShadowHOffset != original.ShadowHOffset {
+		t.Errorf("ShadowHOffset mismatch: got %d, want %d", decoded.ShadowHOffset, original.ShadowHOffset)
+	}
+	if decoded.ShadowVOffset != original.ShadowVOffset {
+		t.Errorf("ShadowVOffset mismatch: got %d, want %d", decoded.ShadowVOffset, original.ShadowVOffset)
+	}
+	if decoded.ShadowStyle != original.ShadowStyle {
+		t.Errorf("ShadowStyle mismatch: got %d, want %d", decoded.ShadowStyle, original.ShadowStyle)
+	}
+}
+
+func TestFavoritesStore_JSONRoundTrip(t *testing.T) {
+	original := FavoritesStore{
+		Favorites: []Favorite{
+			{ID: "fav-1", Name: "First", Text: "Hello"},
+			{ID: "fav-2", Name: "Second", Text: "World"},
+		},
+	}
+
+	data, err := json.Marshal(original)
+	if err != nil {
+		t.Fatalf("failed to marshal FavoritesStore: %v", err)
+	}
+
+	var decoded FavoritesStore
+	err = json.Unmarshal(data, &decoded)
+	if err != nil {
+		t.Fatalf("failed to unmarshal FavoritesStore: %v", err)
+	}
+
+	if len(decoded.Favorites) != len(original.Favorites) {
+		t.Fatalf("Favorites count mismatch: got %d, want %d", len(decoded.Favorites), len(original.Favorites))
+	}
+
+	for i, fav := range decoded.Favorites {
+		if fav.ID != original.Favorites[i].ID {
+			t.Errorf("Favorite[%d].ID mismatch: got %q, want %q", i, fav.ID, original.Favorites[i].ID)
+		}
+		if fav.Name != original.Favorites[i].Name {
+			t.Errorf("Favorite[%d].Name mismatch: got %q, want %q", i, fav.Name, original.Favorites[i].Name)
+		}
+	}
+}
+
+func TestFavoritesStore_EmptyList(t *testing.T) {
+	store := FavoritesStore{Favorites: []Favorite{}}
+
+	data, err := json.Marshal(store)
+	if err != nil {
+		t.Fatalf("failed to marshal empty FavoritesStore: %v", err)
+	}
+
+	var decoded FavoritesStore
+	err = json.Unmarshal(data, &decoded)
+	if err != nil {
+		t.Fatalf("failed to unmarshal empty FavoritesStore: %v", err)
+	}
+
+	if decoded.Favorites == nil {
+		t.Error("Favorites should not be nil after unmarshal")
+	}
+	if len(decoded.Favorites) != 0 {
+		t.Errorf("Favorites should be empty, got %d items", len(decoded.Favorites))
+	}
+}

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -384,7 +384,7 @@ func (m *model) exportBinaryFormat(filename, formatName string) {
 
 	switch formatName {
 	case "PNG":
-		options := export.DefaultPNGOptions()
+		options := export.TerminalAspectRatioPNGOptions()
 		content, err = export.GeneratePNG(m.uiState.renderedLines, options)
 		if err != nil {
 			m.export.showConfirmation = true

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -1,3 +1,6 @@
+// ABOUTME: Main TUI application entry point and model initialization.
+// ABOUTME: Handles the BubbleTea program lifecycle, key events, and export functionality.
+
 package ui
 
 import (
@@ -9,6 +12,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 	"github.com/superstarryeyes/bit/internal/export"
+	"github.com/superstarryeyes/bit/internal/favorites"
 )
 
 func InitialModel() (model, error) {
@@ -44,6 +48,22 @@ func InitialModel() (model, error) {
 
 	// Initialize export manager
 	exportManager := export.NewExportManager()
+
+	// Initialize favorites manager
+	favoritesManager, err := favorites.NewManager()
+	if err != nil {
+		return model{}, fmt.Errorf("failed to initialize favorites: %w", err)
+	}
+
+	// Initialize favorites name input
+	favNameInput := textinput.New()
+	favNameInput.Placeholder = "Enter name..."
+	favNameInput.Blur()
+	favNameInput.CharLimit = 50
+	favNameInput.Width = 30
+	favNameInput.ShowSuggestions = false
+	favNameInput.TextStyle = filenameInputTextStyle
+	favNameInput.PlaceholderStyle = filenameInputPlaceholderStyle
 
 	// Load available fonts (lazy loading - only metadata)
 	fonts, err := loadFontList()
@@ -106,6 +126,15 @@ func InitialModel() (model, error) {
 			confirmationText: "",            // No confirmation text initially
 			manager:          exportManager, // Store export manager in model
 		},
+		favorites: favoritesModel{
+			manager:          favoritesManager,
+			active:           false,
+			selectedIndex:    0,
+			nameInput:        favNameInput,
+			showNamePrompt:   false,
+			showConfirmation: false,
+			confirmationText: "",
+		},
 		uiState: uiStateModel{
 			focusedPanel:  TextInputPanel, // Start with text input panel
 			usesTwoRows:   false,          // Start with single row layout
@@ -133,6 +162,11 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// Handle export mode first
 		if m.export.active {
 			return m.handleExportModeKeys(msg)
+		}
+
+		// Handle favorites mode
+		if m.favorites.active {
+			return m.handleFavoritesModeKeys(msg)
 		}
 
 		// Reset confirmations on any key press
@@ -175,6 +209,9 @@ func (m *model) handleInputModeKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		} else if m.export.filenameInput.Focused() {
 			// Handle filename input when focused
 			m.export.filenameInput, cmd = m.export.filenameInput.Update(msg)
+		} else if m.favorites.nameInput.Focused() {
+			// Handle favorites name input when focused
+			m.favorites.nameInput, cmd = m.favorites.nameInput.Update(msg)
 		}
 	}
 
@@ -208,6 +245,8 @@ func (m *model) handleNormalModeKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.handleEnterExportMode()
 	case "r":
 		m.handleRandomize()
+	case "f":
+		m.handleEnterFavoritesMode()
 	default:
 		// Handle text input when focused
 		if m.textInput.input.Focused() {
@@ -288,7 +327,15 @@ func (m *model) exportText() {
 		return
 	}
 
-	// Generate content based on selected format
+	formatName := m.export.format
+
+	// Check if this is a binary format (like PNG)
+	if m.export.manager.IsBinaryFormat(formatName) {
+		m.exportBinaryFormat(sanitizedFilename, formatName)
+		return
+	}
+
+	// Generate content based on selected format (text formats)
 	var content string
 	switch m.export.format {
 	case "TXT":
@@ -307,9 +354,6 @@ func (m *model) exportText() {
 		// Default to TXT if format not recognized
 		content = export.GenerateTXTCode(m.uiState.renderedLines)
 	}
-
-	// Use the canonical format name directly (e.g., "TXT", "GO", etc.)
-	formatName := m.export.format
 
 	// Check if file exists before attempting export
 	exists, finalFilename, err := m.export.manager.CheckFileExists(sanitizedFilename, formatName)
@@ -331,6 +375,69 @@ func (m *model) exportText() {
 
 	// File doesn't exist, proceed with export
 	m.performExport(content, sanitizedFilename, formatName)
+}
+
+// exportBinaryFormat handles export of binary formats like PNG
+func (m *model) exportBinaryFormat(filename, formatName string) {
+	var content []byte
+	var err error
+
+	switch formatName {
+	case "PNG":
+		options := export.DefaultPNGOptions()
+		content, err = export.GeneratePNG(m.uiState.renderedLines, options)
+		if err != nil {
+			m.export.showConfirmation = true
+			m.export.confirmationText = fmt.Sprintf("PNG generation failed: %v", err)
+			return
+		}
+	default:
+		m.export.showConfirmation = true
+		m.export.confirmationText = fmt.Sprintf("Unknown binary format: %s", formatName)
+		return
+	}
+
+	// Check if file exists before attempting export
+	exists, finalFilename, err := m.export.manager.CheckFileExists(filename, formatName)
+	if err != nil {
+		m.export.showConfirmation = true
+		m.export.confirmationText = fmt.Sprintf("Export failed: %v", err)
+		return
+	}
+
+	if exists {
+		// Show overwrite prompt with binary content
+		m.export.showOverwritePrompt = true
+		m.export.overwriteFilename = finalFilename
+		m.export.overwriteBinaryContent = content
+		m.export.overwriteContent = "" // Clear text content
+		m.export.overwriteFormat = formatName
+		m.export.selectedButton = 1 // Default to "No"
+		return
+	}
+
+	// File doesn't exist, proceed with export
+	m.performBinaryExport(content, filename, formatName)
+}
+
+// performBinaryExport writes binary content to file
+func (m *model) performBinaryExport(content []byte, filename, formatName string) {
+	err := m.export.manager.ExportBinary(content, filename, formatName)
+	if err != nil {
+		m.export.showConfirmation = true
+		m.export.confirmationText = fmt.Sprintf("Export failed: %v", err)
+		return
+	}
+
+	// Set export confirmation message using the actual filename that was saved
+	cwd, _ := os.Getwd()
+	sanitizedFilename := export.SanitizeFilename(filename)
+	format := m.export.manager.GetFormatByName(formatName)
+	if format != nil && !strings.HasSuffix(sanitizedFilename, format.Extension) {
+		sanitizedFilename += format.Extension
+	}
+	m.export.showConfirmation = true
+	m.export.confirmationText = fmt.Sprintf("Exported to %s/%s", cwd, sanitizedFilename)
 }
 
 // performExport actually writes the file
@@ -368,6 +475,11 @@ func (m model) View() string {
 	// If in export mode, show export UI instead of normal UI
 	if m.export.active {
 		return m.renderExportView()
+	}
+
+	// If in favorites mode, show favorites UI
+	if m.favorites.active {
+		return m.renderFavoritesView()
 	}
 
 	// Calculate heights for different sections

--- a/internal/ui/font_loader.go
+++ b/internal/ui/font_loader.go
@@ -3,7 +3,7 @@ package ui
 import (
 	"encoding/json"
 	"fmt"
-	"path/filepath"
+	"path"
 	"sort"
 	"strings"
 
@@ -22,8 +22,8 @@ func loadFontList() ([]FontInfo, error) {
 	}
 
 	for _, entry := range entries {
-		if filepath.Ext(entry.Name()) == ".bit" {
-			fontPath := filepath.Join("fonts", entry.Name())
+		if path.Ext(entry.Name()) == ".bit" {
+			fontPath := path.Join("fonts", entry.Name())
 
 			// For lazy loading, we only load the font name from the file
 			// This is much more efficient than loading the entire font data

--- a/internal/ui/types.go
+++ b/internal/ui/types.go
@@ -1,8 +1,12 @@
+// ABOUTME: Type definitions for the TUI application models and state.
+// ABOUTME: Contains all sub-models for text, font, spacing, color, scale, shadow, and export.
+
 package ui
 
 import (
-	"github.com/superstarryeyes/bit/internal/export"
 	"github.com/charmbracelet/bubbles/textinput"
+	"github.com/superstarryeyes/bit/internal/export"
+	"github.com/superstarryeyes/bit/internal/favorites"
 )
 
 // textInputModel handles text entry and alignment
@@ -58,17 +62,18 @@ type shadowModel struct {
 
 // exportModel handles export functionality
 type exportModel struct {
-	active              bool                  // Whether we're in export mode
-	format              string                // Selected export format
-	filenameInput       textinput.Model       // Text input for filename
-	showConfirmation    bool                  // Whether to show export confirmation in header
-	confirmationText    string                // The confirmation text to display
-	showOverwritePrompt bool                  // Whether to show overwrite confirmation
-	overwriteFilename   string                // Filename that would be overwritten
-	overwriteContent    string                // Content to write if user confirms
-	overwriteFormat     string                // Format for the overwrite
-	selectedButton      int                   // 0 = Yes, 1 = No
-	manager             *export.ExportManager // Export manager for format information
+	active               bool                  // Whether we're in export mode
+	format               string                // Selected export format
+	filenameInput        textinput.Model       // Text input for filename
+	showConfirmation     bool                  // Whether to show export confirmation in header
+	confirmationText     string                // The confirmation text to display
+	showOverwritePrompt  bool                  // Whether to show overwrite confirmation
+	overwriteFilename    string                // Filename that would be overwritten
+	overwriteContent     string                // Content to write if user confirms (text formats)
+	overwriteBinaryContent []byte              // Content to write if user confirms (binary formats like PNG)
+	overwriteFormat      string                // Format for the overwrite
+	selectedButton       int                   // 0 = Yes, 1 = No
+	manager              *export.ExportManager // Export manager for format information
 }
 
 // uiStateModel handles general UI state
@@ -80,6 +85,17 @@ type uiStateModel struct {
 	usesTwoRows   bool     // Cache the layout decision to prevent flickering
 }
 
+// favoritesModel handles favorites functionality
+type favoritesModel struct {
+	manager          *favorites.Manager // Favorites manager for persistence
+	active           bool               // Whether favorites view is open
+	selectedIndex    int                // Currently selected favorite in list
+	nameInput        textinput.Model    // Text input for naming new favorites
+	showNamePrompt   bool               // Whether showing the name input prompt
+	showConfirmation bool               // Whether to show confirmation message
+	confirmationText string             // Confirmation text to display
+}
+
 // model is the main application model composed of sub-models
 type model struct {
 	textInput textInputModel
@@ -89,6 +105,7 @@ type model struct {
 	scale     scaleModel
 	shadow    shadowModel
 	export    exportModel
+	favorites favoritesModel
 	uiState   uiStateModel
 }
 

--- a/internal/ui/view_renderers.go
+++ b/internal/ui/view_renderers.go
@@ -8,8 +8,8 @@ import (
 	"strings"
 	"unicode/utf8"
 
-	"github.com/superstarryeyes/bit/internal/export"
 	"github.com/charmbracelet/lipgloss"
+	"github.com/superstarryeyes/bit/internal/export"
 )
 
 // ansiRegex is compiled once at package level for efficiency
@@ -267,7 +267,7 @@ func (m model) renderExportView() string {
 
 	instructions := lipgloss.NewStyle().
 		Foreground(lipgloss.Color(ColorFaint)).
-		Render("←→: Select format, Write filename and press ENTER to export, ESC to cancel")
+		Render("TAB: Select format, Write filename and press ENTER to export, ESC to cancel")
 
 	cwd, err := os.Getwd()
 	if err != nil {


### PR DESCRIPTION
## Summary

- Fix PNG aspect ratio to match terminal display (2:1 height:width ratio)
- Add `TerminalAspectRatioPNGOptions()` for proper cell sizing (16x32 pixels)
- Change default export location to user's Desktop
- Make PNG the default/first export format option
- Add tests for terminal aspect ratio PNG generation

## Changes

- `internal/export/png.go`: Added `TerminalAspectRatioPNGOptions()` function
- `internal/export/manager.go`: Export now saves to Desktop by default
- `internal/export/types.go`: Moved PNG to first position in format list
- `internal/ui/app.go`: Use terminal aspect ratio options for PNG export
- `README.md`: Updated documentation to reflect PNG export feature

## Test plan

- [x] PNG export produces correct aspect ratio matching terminal display
- [x] Files save to Desktop by default
- [x] PNG is the default export format when pressing 'e'
- [x] All existing tests pass