### PR TITLE
fix kerning

### DIFF
--- a/ansifonts/render.go
+++ b/ansifonts/render.go
@@ -437,10 +437,9 @@ func renderTextWithFont(text string, fontData FontData, baseCharSpacing int, wor
 	charHeights := make(map[string]int)          // Track individual character heights
 	charOffsets := make(map[string]int)          // Track vertical offset for proper descender alignment
 	adjustedBitmaps := make(map[string][]string) // Cache adjusted character bitmaps
-	kerningCache := make(map[[2]string]int)
 
 	runes := []rune(text)
-	for i, r := range runes {
+	for _, r := range runes {
 		charStr := string(r)
 		if _, exists := charWidths[charStr]; !exists {
 			if charStr == " " {
@@ -499,30 +498,52 @@ func renderTextWithFont(text string, fontData FontData, baseCharSpacing int, wor
 				adjustedBitmaps[charStr] = []string{strings.Repeat(" ", defaultMissingCharWidth)}
 			}
 		}
-
-		// Pre-calculate kerning for pairs
-		if i < len(runes)-1 {
-			nextCharStr := string(runes[i+1])
-			pair := [2]string{charStr, nextCharStr}
-			if _, exists := kerningCache[pair]; !exists {
-				if charStr == " " || nextCharStr == " " {
-					kerningCache[pair] = 0
-				} else {
-					// Use adjusted bitmaps for kerning calculation to account for descender alignment
-					leftBitmap, leftExists := adjustedBitmaps[charStr]
-					rightBitmap, rightExists := adjustedBitmaps[nextCharStr]
-
-					if !leftExists || !rightExists {
-						kerningCache[pair] = 0
-					} else {
-						kerningCache[pair] = computeKerning(leftBitmap, rightBitmap)
-					}
-				}
-			}
-		}
 	}
 
 	var result []string
+
+	// Pre-calculate character-level kerning data (including half-pixel adjustments)
+	// This is calculated once per character pair, outside the row loop
+	type kerningData struct {
+		spacing         int
+		halfPixelAdjust float64
+	}
+	pairKerningData := make(map[[2]string]kerningData)
+
+	for i := 0; i < len(runes)-1; i++ {
+		charStr := string(runes[i])
+		nextCharStr := string(runes[i+1])
+
+		if charStr == " " || nextCharStr == " " {
+			pairKerningData[[2]string{charStr, nextCharStr}] = kerningData{spacing: 0, halfPixelAdjust: 0}
+			continue
+		}
+
+		// Use adjusted bitmaps for kerning calculation to account for descender alignment
+		leftBitmap, leftExists := adjustedBitmaps[charStr]
+		rightBitmap, rightExists := adjustedBitmaps[nextCharStr]
+
+		var optimalInterCharSpacing int
+		if !leftExists || !rightExists {
+			optimalInterCharSpacing = 0
+		} else {
+			optimalInterCharSpacing = computeKerning(leftBitmap, rightBitmap)
+		}
+
+		// Calculate half-pixel adjustment based on height difference between character pair
+		// If the combined heights differ by an odd number, we need a half-pixel adjustment
+		// for proper alignment
+		heightDiff := charHeights[charStr] - charHeights[nextCharStr]
+		var halfPixelAdjust float64
+		if heightDiff%2 != 0 {
+			halfPixelAdjust = 0.5
+		}
+
+		pairKerningData[[2]string{charStr, nextCharStr}] = kerningData{
+			spacing:         optimalInterCharSpacing,
+			halfPixelAdjust: halfPixelAdjust,
+		}
+	}
 
 	// Render the text row by row
 	for i := range maxCharHeight {
@@ -550,16 +571,11 @@ func renderTextWithFont(text string, fontData FontData, baseCharSpacing int, wor
 					}
 				} else {
 					prevCharTotalAdvance = float64(charWidths[prevCharStr])
-					optimalInterCharSpacing := kerningCache[[2]string{prevCharStr, charStr}]
 
-					// Handle half-pixel spacing for odd/even height differences
-					heightDiff := charHeights[prevCharStr] - charHeights[charStr]
-					halfPixelAdjustment := 0.0
-
-					// If heights differ by an odd number, adjust by half a pixel
-					if heightDiff%2 != 0 && i >= charHeights[charStr] {
-						halfPixelAdjustment = 0.5
-					}
+					// Use pre-calculated kerning data for this character pair
+					kd := pairKerningData[[2]string{prevCharStr, charStr}]
+					optimalInterCharSpacing := kd.spacing
+					halfPixelAdjustment := kd.halfPixelAdjust
 
 					if baseCharSpacing == 0 {
 						prevCharTotalAdvance += float64(optimalInterCharSpacing) + halfPixelAdjustment


### PR DESCRIPTION
Fixes kerning with some custom fonts:

Before:
<img width="933" height="663" alt="Screenshot 2026-02-20 at 10 00 03 PM" src="https://github.com/user-attachments/assets/46bcb429-3b5c-4143-b3cb-91a90396fe0d" />

After:
<img width="932" height="665" alt="Screenshot 2026-02-20 at 10 00 07 PM" src="https://github.com/user-attachments/assets/911d0421-b174-4e16-a32e-21c30ef1853a" />

AI assisted fix:

## Problem Analysis
The issue is in ansifonts/render.go. The half-pixel adjustment logic has a flaw:

```go
heightDiff := charHeights[prevCharStr] - charHeights[charStr]
halfPixelAdjustment := 0.0
if heightDiff%2 != 0 && i >= charHeights[charStr] {
    halfPixelAdjustment = 0.5
}
```

**Problem**: This half-pixel adjustment is applied inside the row loop (for i := range maxCharHeight) but calculated using the same heightDiff for all rows. Additionally, the kerning value is pre-computed once per character pair but the half-pixel adjustment is applied per-row, causing inconsistency.

**Summary of changes**:
1. Moved half-pixel adjustment calculation outside the row loop - Previously, the half-pixel adjustment was calculated inside the per-row loop (lines 555-562), which caused inconsistent spacing because it was recalculated for every row with the condition i >= charHeights[charStr] (where i is the current row).
2. Pre-calculate kerning data once per character pair - Created a pairKerningData map that stores both the kerning value and half-pixel adjustment for each character pair, calculated once before the row rendering loop.
3. Removed redundant kerningCache - Simplified the code by combining the kerning calculation and half-pixel adjustment into a single pass.
The fix ensures that character spacing is now calculated consistently based on the character pair's properties (their heights), rather than being recalculated per-row which caused visual inconsistencies.
