### PR TITLE
Add feature cli fit mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,7 +252,7 @@ measured width/height and distance (`dw/dh`) in each preview header.
 | **Flag**         | **Description**                           | **Values**                          |
 | ---------------- | ----------------------------------------- | ----------------------------------- |
 | `-fit-fonts`     | CSV list of fonts to test                 | Font names (default: all)           |
-| `-fit-scales`    | CSV list of scale factors or scale steps  | `-1,0,1,2` or `0.5,1,2,4`           |
+| `-fit-scales`    | CSV list of scale indices                 | `-1,0,1,2`                          |
 | `-fit-width`     | Target width                              | Integer (0 disables width scoring)  |
 | `-fit-height`    | Target height                             | Integer (0 disables height scoring) |
 | `-fit-priority`  | Dimension priority for sorting            | `width` or `height`                 |

--- a/README.md
+++ b/README.md
@@ -3,12 +3,16 @@
 <img src="https://github.com/superstarryeyes/bit/blob/main/images/bit-icon.png?raw=true" alt="Bit Icon" width="35%" />
 
 ### Bit - Terminal ANSI Logo Designer & Font Library
+
 [![License: MIT](https://img.shields.io/badge/License-MIT-05bd7e.svg)](LICENSE)
 [![Terminal](https://img.shields.io/badge/interface-terminal-05bd7e.svg)](https://github.com/superstarryeyes/bit)
 [![Go](https://img.shields.io/badge/Go-1.25+-05bd7e.svg)](https://golang.org)
 [![Discord](https://img.shields.io/badge/Discord-Join%20our%20Community-5865F2?logo=discord&logoColor=white)](https://discord.gg/z8sE2gnMNk)
 
-[Features](#-features) • [Quick Start](#-quick-start) • [Installation](#-installation) • [Usage](#-usage) • [Library](#-library) • [Font Collection](#%EF%B8%8F-font-collection) • [Contributing](#️-contributing) • [License](#-license) • [Acknowledgments](#-acknowledgments)
+[Features](#-features) • [Quick Start](#-quick-start) •
+[Installation](#-installation) • [Usage](#-usage) • [Library](#-library) •
+[Font Collection](#%EF%B8%8F-font-collection) • [Contributing](#️-contributing)
+• [License](#-license) • [Acknowledgments](#-acknowledgments)
 
 <img src="https://github.com/superstarryeyes/bit/blob/main/images/bit-screenshot.gif" alt="Bit Screenshot" width="100%" />
 
@@ -18,16 +22,16 @@
 
 ## ✨ Features
 
-| **Feature**                             | **Description**                                                                                |
-| --------------------------------------- | ---------------------------------------------------------------------------------------------- |
-| **🌟 100+ Font Styles**               | Classic terminal, retro gaming, modern pixel, decorative, and monospace fonts. All free for commercial and personal use.                  |
-| **📤 Multi-Format Export**              | Export to TXT, Go, JavaScript, Python, Rust, and Bash with language-specific formatting.               |
-| **🎨 Advanced Text Effects**            | Color gradient effects (horizontal & vertical), shadow effects (horizontal & vertical), and text scaling (0.5×–4×).|
-| **🌈 Rich Color Support**               | 14 vibrant predefined UI colors that can be combined with gradients. The library and CLI also accept any hex color for unlimited possibilities.|
-| **📐 Alignment & Spacing**                   | Adjust character, word, and line spacing. Align text left, center, or right.          |
-| **⚡️ Smart Typography**                 | Automatic kerning, descender detection and alignment.           |
-| **🛠️ Powerful CLI Tool**                | Render text quickly with extended options for fonts, colors, spacing, and effects.            |
-| **📚 Standalone Go Library**           | A simple, self-contained API with type-safe enums for effortless programmatic ANSI text rendering.                           |
+| **Feature**                  | **Description**                                                                                                                                 |
+| ---------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| **🌟 100+ Font Styles**      | Classic terminal, retro gaming, modern pixel, decorative, and monospace fonts. All free for commercial and personal use.                        |
+| **📤 Multi-Format Export**   | Export to TXT, Go, JavaScript, Python, Rust, and Bash with language-specific formatting.                                                        |
+| **🎨 Advanced Text Effects** | Color gradient effects (horizontal & vertical), shadow effects (horizontal & vertical), and text scaling (0.5×–4×).                             |
+| **🌈 Rich Color Support**    | 14 vibrant predefined UI colors that can be combined with gradients. The library and CLI also accept any hex color for unlimited possibilities. |
+| **📐 Alignment & Spacing**   | Adjust character, word, and line spacing. Align text left, center, or right.                                                                    |
+| **⚡️ Smart Typography**      | Automatic kerning, descender detection and alignment.                                                                                           |
+| **🛠️ Powerful CLI Tool**     | Render text quickly with extended options for fonts, colors, spacing, and effects.                                                              |
+| **📚 Standalone Go Library** | A simple, self-contained API with type-safe enums for effortless programmatic ANSI text rendering.                                              |
 
 ---
 
@@ -59,14 +63,17 @@ curl -sfL https://raw.githubusercontent.com/superstarryeyes/bit/main/install.sh 
 ```
 
 This installs `bit` to `/usr/local/bin`. The binary works in two modes:
+
 - **Interactive UI**: Run `bit` with no arguments
 - **CLI mode**: Run `bit [options] <text>` to render directly
 
 ### Manual Installation
 
-Download the latest release for your platform from the [Releases page](https://github.com/superstarryeyes/bit/releases).
+Download the latest release for your platform from the
+[Releases page](https://github.com/superstarryeyes/bit/releases).
 
 **Available for:**
+
 - Linux (x86_64, arm64)
 - macOS (x86_64, arm64)
 - Windows (x86_64, arm64)
@@ -100,7 +107,8 @@ go build -o bit ./cmd/bit
 ```
 
 > [!NOTE]
-> Fonts are embedded using `go:embed`, ensuring the binaries are fully self-contained.
+> Fonts are embedded using `go:embed`, ensuring the binaries are fully
+> self-contained.
 
 ---
 
@@ -131,60 +139,69 @@ bit -help
 
 ### Interactive UI - Keyboard Controls
 
-| **Key Binding**                         | **Action Description**                                                                         |
-| --------------------------------------- | ---------------------------------------------------------------------------------------------- |
-| `← →`                                   | Navigate between the 6 main control panels                                                     |
-| `Tab`                                   | Access sub-modes within panels   |
-| `↑ ↓`                                   | Adjust values in the currently selected panel or navigate text rows in multi-line mode        |
-| `Enter`                                 | Activate/deactivate text input mode for editing      |
-| `r`                                     | Randomize font, colors, and gradient settings for instant inspiration                          |
-| `e`                                     | Enter export mode to save your creation in various formats                                     |
-| `Esc`                                   | Quit the application and return to terminal                                                    |
+| **Key Binding** | **Action Description**                                                                 |
+| --------------- | -------------------------------------------------------------------------------------- |
+| `← →`           | Navigate between the 6 main control panels                                             |
+| `Tab`           | Access sub-modes within panels                                                         |
+| `↑ ↓`           | Adjust values in the currently selected panel or navigate text rows in multi-line mode |
+| `Enter`         | Activate/deactivate text input mode for editing                                        |
+| `r`             | Randomize font, colors, and gradient settings for instant inspiration                  |
+| `e`             | Enter export mode to save your creation in various formats                             |
+| `Esc`           | Quit the application and return to terminal                                            |
 
 ### Control Panels
 
-The UI features **6 main control panels** with sub-modes accessible via **Tab** key:
+The UI features **6 main control panels** with sub-modes accessible via **Tab**
+key:
 
 #### 1. 🔴 **Text Input Panel** (2 modes)
-   - **Text Input Mode**: Enter and edit text with multi-line support
-     - Press `↓` to create new row
-     - Press `↑↓` to navigate between rows
-     - Cursor positions are tracked per-row
-     - The row count is shown in label when editing multiple rows
-   - **Text Alignment Mode**: Choose Left, Center, or Right alignment
+
+- **Text Input Mode**: Enter and edit text with multi-line support
+  - Press `↓` to create new row
+  - Press `↑↓` to navigate between rows
+  - Cursor positions are tracked per-row
+  - The row count is shown in label when editing multiple rows
+- **Text Alignment Mode**: Choose Left, Center, or Right alignment
 
 #### 2. 🟢 **Font Selection Panel**
-   - Browse through 100+ available bitmap fonts
-   - Shows "Font X/XXX" in label
-   - Fonts are lazy loaded on first use for memory efficiency
+
+- Browse through 100+ available bitmap fonts
+- Shows "Font X/XXX" in label
+- Fonts are lazy loaded on first use for memory efficiency
 
 #### 3. 🔵 **Spacing Panel** (3 modes)
-   - Character Spacing: 0 to 10 pixels between characters
-   - Word Spacing: 0 to 20 pixels for multi-word lines
-   - Line Spacing: 0 to 10 pixels for multi-line text layout
+
+- Character Spacing: 0 to 10 pixels between characters
+- Word Spacing: 0 to 20 pixels for multi-word lines
+- Line Spacing: 0 to 10 pixels for multi-line text layout
 
 #### 4. 🟡 **Color Panel** (3 modes)
-   - **Text Color 1**: Primary text color (14 ANSI colors)
-   - **Text Color 2**: Gradient end color
-     - Gradient auto-enables when different from Text Color 1
-     - Shows "None" when same as Text Color 1
-   - **Gradient Direction**: Up-Down, Down-Up, Left-Right, Right-Left
+
+- **Text Color 1**: Primary text color (14 ANSI colors)
+- **Text Color 2**: Gradient end color
+  - Gradient auto-enables when different from Text Color 1
+  - Shows "None" when same as Text Color 1
+- **Gradient Direction**: Up-Down, Down-Up, Left-Right, Right-Left
 
 #### 5. 🟣 **Text Scale Panel**
-   - Four scale options: 0.5x, 1x, 2x, 4x
-   - Uses ANSI-aware scaling algorithm
-   - Handles half-pixel characters correctly
+
+- Four scale options: 0.5x, 1x, 2x, 4x
+- Uses ANSI-aware scaling algorithm
+- Handles half-pixel characters correctly
 
 #### 6. ⚫ **Shadow Panel** (3 modes)
-   - **Horizontal Shadow**: -5 to 5 pixels (← or →)
-     - Shows "Off" at 0 position
-   - **Vertical Shadow**: -5 to 5 pixels (↑ or ↓)
-     - Shows "Off" at 0 position
-   - **Shadow Style**: Light (░), Medium (▒), Dark (▓)
-     - Visual preview shows actual ANSI character repeated
+
+- **Horizontal Shadow**: -5 to 5 pixels (← or →)
+  - Shows "Off" at 0 position
+- **Vertical Shadow**: -5 to 5 pixels (↑ or ↓)
+  - Shows "Off" at 0 position
+- **Shadow Style**: Light (░), Medium (▒), Dark (▓)
+  - Visual preview shows actual ANSI character repeated
 
 > [!WARNING]
-> If shadows are enabled with half-pixel characters, a warning appears in the title bar. The library automatically disables shadows in this case to prevent visual artifacts.
+> If shadows are enabled with half-pixel characters, a warning appears in the
+> title bar. The library automatically disables shadows in this case to prevent
+> visual artifacts.
 
 ### CLI Mode
 
@@ -219,48 +236,72 @@ bit -font pressstart -color 32 -scale 1 "2X"
 
 # Aligned text
 bit -font gohufontb -color 93 -align right "Go\nRight"
+
+# Fit mode (rank fonts by target size)
+bit -fit-width 40 -fit-height 10 -fit-scales -1,0,1 -fit-show-dims "Hello"
 ```
+
+#### Fit Mode
+
+Fit mode ranks fonts by how close their rendered output is to a target size.
+Previews are always shown for the top matches. Use `-fit-show-dims` to include
+measured width/height and distance (`dw/dh`) in each preview header.
+
+#### Fit Mode Options
+
+| **Flag**         | **Description**                           | **Values**                          |
+| ---------------- | ----------------------------------------- | ----------------------------------- |
+| `-fit-fonts`     | CSV list of fonts to test                 | Font names (default: all)           |
+| `-fit-scales`    | CSV list of scale factors or scale steps  | `-1,0,1,2` or `0.5,1,2,4`           |
+| `-fit-width`     | Target width                              | Integer (0 disables width scoring)  |
+| `-fit-height`    | Target height                             | Integer (0 disables height scoring) |
+| `-fit-priority`  | Dimension priority for sorting            | `width` or `height`                 |
+| `-fit-limit`     | Max results to preview                    | Integer (default: 10)               |
+| `-fit-show-dims` | Show measured `w/h` and distances `dw/dh` | true/false                          |
 
 #### CLI Options
 
-| **Flag**          | **Description**                | **Values**                              |
-| ----------------- | ------------------------------ | --------------------------------------- |
-| `-font`           | Font name to use               | Any available font name (default: first font)                 |
-| `-color`          | Text color                     | ANSI codes (30-37, 90-96) or hex (#FF0000) |
-| `-gradient`       | Gradient end color             | ANSI codes (30-37, 90-96) or hex (#0000FF) |
-| `-direction`      | Gradient direction             | down, up, right, left                   |
-| `-char-spacing`   | Character spacing              | 0 to 10           |
-| `-word-spacing`   | Word spacing                   | 0 to 20                                 |
-| `-line-spacing`   | Line spacing                   | 0 to 10                                 |
-| `-scale`          | Text scale factor              | -1 (0.5x), 0 (1x), 1 (2x), 2 (4x)      |
-| `-shadow`         | Enable shadow effect           | true/false                              |
-| `-shadow-h`       | Shadow horizontal offset       | -5 to 5                                 |
-| `-shadow-v`       | Shadow vertical offset         | -5 to 5                                 |
-| `-shadow-style`   | Shadow style                   | 0 (light), 1 (medium), 2 (dark)        |
-| `-align`          | Text alignment                 | left, center, right                     |
-| `-list`           | List all available fonts       | -                                       |
+| **Flag**        | **Description**          | **Values**                                    |
+| --------------- | ------------------------ | --------------------------------------------- |
+| `-font`         | Font name to use         | Any available font name (default: first font) |
+| `-color`        | Text color               | ANSI codes (30-37, 90-96) or hex (#FF0000)    |
+| `-gradient`     | Gradient end color       | ANSI codes (30-37, 90-96) or hex (#0000FF)    |
+| `-direction`    | Gradient direction       | down, up, right, left                         |
+| `-char-spacing` | Character spacing        | 0 to 10                                       |
+| `-word-spacing` | Word spacing             | 0 to 20                                       |
+| `-line-spacing` | Line spacing             | 0 to 10                                       |
+| `-scale`        | Text scale factor        | -1 (0.5x), 0 (1x), 1 (2x), 2 (4x)             |
+| `-shadow`       | Enable shadow effect     | true/false                                    |
+| `-shadow-h`     | Shadow horizontal offset | -5 to 5                                       |
+| `-shadow-v`     | Shadow vertical offset   | -5 to 5                                       |
+| `-shadow-style` | Shadow style             | 0 (light), 1 (medium), 2 (dark)               |
+| `-align`        | Text alignment           | left, center, right                           |
+| `-list`         | List all available fonts | -                                             |
 
 #### Available Colors
 
-| **Code** | **Color**       | **Preview** | **Code** | **Color**        | **Preview** |
-| -------- | --------------- | ----------- | -------- | ---------------- | ----------- |
-| 30       | Black           | ![Black](https://img.shields.io/badge/Black-%23000000-black) | 90       | Gray             | ![Gray](https://img.shields.io/badge/Gray-%23808080-808080) |
-| 31       | Red             | ![Red](https://img.shields.io/badge/Red-%23CD3131-CD3131) | 91       | Bright Red       | ![Bright Red](https://img.shields.io/badge/Bright%20Red-%23FF9999-FF9999) |
-| 32       | Green           | ![Green](https://img.shields.io/badge/Green-%230DBC79-0DBC79) | 92       | Bright Green     | ![Bright Green](https://img.shields.io/badge/Bright%20Green-%2399FF99-99FF99) |
-| 33       | Yellow          | ![Yellow](https://img.shields.io/badge/Yellow-%23E5E510-E5E510) | 93       | Bright Yellow    | ![Bright Yellow](https://img.shields.io/badge/Bright%20Yellow-%23FFFF99-FFFF99) |
-| 34       | Blue            | ![Blue](https://img.shields.io/badge/Blue-%232472C8-2472C8) | 94       | Bright Blue      | ![Bright Blue](https://img.shields.io/badge/Bright%20Blue-%2366BBFF-66BBFF) |
-| 35       | Magenta         | ![Magenta](https://img.shields.io/badge/Magenta-%23BC3FBC-BC3FBC) | 95       | Bright Magenta   | ![Bright Magenta](https://img.shields.io/badge/Bright%20Magenta-%23FF99FF-FF99FF) |
-| 36       | Cyan            | ![Cyan](https://img.shields.io/badge/Cyan-%2311A8CD-11A8CD) | 96       | Bright Cyan      | ![Bright Cyan](https://img.shields.io/badge/Bright%20Cyan-%2399FFFF-99FFFF) |
-| 37       | White           | ![White](https://img.shields.io/badge/White-%23E5E5E5-E5E5E5) | 97       | Bright White     | ![Bright White](https://img.shields.io/badge/Bright%20White-%23FFFFFF-FFFFFF) |
+| **Code** | **Color** | **Preview**                                                       | **Code** | **Color**      | **Preview**                                                                       |
+| -------- | --------- | ----------------------------------------------------------------- | -------- | -------------- | --------------------------------------------------------------------------------- |
+| 30       | Black     | ![Black](https://img.shields.io/badge/Black-%23000000-black)      | 90       | Gray           | ![Gray](https://img.shields.io/badge/Gray-%23808080-808080)                       |
+| 31       | Red       | ![Red](https://img.shields.io/badge/Red-%23CD3131-CD3131)         | 91       | Bright Red     | ![Bright Red](https://img.shields.io/badge/Bright%20Red-%23FF9999-FF9999)         |
+| 32       | Green     | ![Green](https://img.shields.io/badge/Green-%230DBC79-0DBC79)     | 92       | Bright Green   | ![Bright Green](https://img.shields.io/badge/Bright%20Green-%2399FF99-99FF99)     |
+| 33       | Yellow    | ![Yellow](https://img.shields.io/badge/Yellow-%23E5E510-E5E510)   | 93       | Bright Yellow  | ![Bright Yellow](https://img.shields.io/badge/Bright%20Yellow-%23FFFF99-FFFF99)   |
+| 34       | Blue      | ![Blue](https://img.shields.io/badge/Blue-%232472C8-2472C8)       | 94       | Bright Blue    | ![Bright Blue](https://img.shields.io/badge/Bright%20Blue-%2366BBFF-66BBFF)       |
+| 35       | Magenta   | ![Magenta](https://img.shields.io/badge/Magenta-%23BC3FBC-BC3FBC) | 95       | Bright Magenta | ![Bright Magenta](https://img.shields.io/badge/Bright%20Magenta-%23FF99FF-FF99FF) |
+| 36       | Cyan      | ![Cyan](https://img.shields.io/badge/Cyan-%2311A8CD-11A8CD)       | 96       | Bright Cyan    | ![Bright Cyan](https://img.shields.io/badge/Bright%20Cyan-%2399FFFF-99FFFF)       |
+| 37       | White     | ![White](https://img.shields.io/badge/White-%23E5E5E5-E5E5E5)     | 97       | Bright White   | ![Bright White](https://img.shields.io/badge/Bright%20White-%23FFFFFF-FFFFFF)     |
 
 > [!TIP]
-> The CLI and library support **any hex color** (e.g., `-color "#FF5733"`), providing unlimited color possibilities beyond the ANSI palette.
+> The CLI and library support **any hex color** (e.g., `-color "#FF5733"`),
+> providing unlimited color possibilities beyond the ANSI palette.
 
 ---
 
 ## 📚 Library
 
-Bit includes a **powerful standalone Go library** (`ansifonts`) that's completely independent of the TUI. The library can be imported into any Go project without any TUI dependencies.
+Bit includes a **powerful standalone Go library** (`ansifonts`) that's
+completely independent of the TUI. The library can be imported into any Go
+project without any TUI dependencies.
 
 ### Quick Library Example
 
@@ -308,14 +349,17 @@ func main() {
 	}
 }
 ```
+
 > [!TIP]
-> See the [ansifonts library documentation](ansifonts/README.md) for detailed API reference and examples.
+> See the [ansifonts library documentation](ansifonts/README.md) for detailed
+> API reference and examples.
 
 ---
 
 ## 🗂️ Font Collection
 
-The project includes **100+ carefully curated bitmap fonts** embedded in the binary.
+The project includes **100+ carefully curated bitmap fonts** embedded in the
+binary.
 
 Fonts are stored as `.bit` files (JSON format) containing:
 
@@ -333,22 +377,26 @@ Fonts are stored as `.bit` files (JSON format) containing:
 ```
 
 > [!NOTE]
-> Each font file contains a `license` field indicating its specific license terms. All fonts are under permissive open-source licenses, which allow free usage, modification, and distribution for both personal and commercial purposes.
+> Each font file contains a `license` field indicating its specific license
+> terms. All fonts are under permissive open-source licenses, which allow free
+> usage, modification, and distribution for both personal and commercial
+> purposes.
 
 ### Export Formats
 
 The interactive UI supports exporting your creations to:
 
-| Format | Extension | Description |
-|--------|-----------|-------------|
-| **TXT** | `.txt` | Plain text with ANSI codes stripped |
-| **Go** | `.go` | Go source code with embedded ANSI strings |
-| **JavaScript** | `.js` | JavaScript array with console.log display function |
-| **Python** | `.py` | Python list with print function |
-| **Rust** | `.rs` | Rust vector with println! macro |
-| **Bash** | `.sh` | Bash script with echo -e for ANSI support |
+| Format         | Extension | Description                                        |
+| -------------- | --------- | -------------------------------------------------- |
+| **TXT**        | `.txt`    | Plain text with ANSI codes stripped                |
+| **Go**         | `.go`     | Go source code with embedded ANSI strings          |
+| **JavaScript** | `.js`     | JavaScript array with console.log display function |
+| **Python**     | `.py`     | Python list with print function                    |
+| **Rust**       | `.rs`     | Rust vector with println! macro                    |
+| **Bash**       | `.sh`     | Bash script with echo -e for ANSI support          |
 
 All exports include:
+
 - Properly escaped ANSI sequences
 - Language-specific string literals
 - Ready-to-run code
@@ -359,7 +407,8 @@ All exports include:
 
 Contributions are welcome! Please feel free to submit a Pull Request.
 
-Join our Discord community for discussions, support and collaboration for creating new Bit fonts.
+Join our Discord community for discussions, support and collaboration for
+creating new Bit fonts.
 
 [![Join our Discord](https://img.shields.io/badge/Discord-Join%20Us-5865F2?logo=discord&style=for-the-badge)](https://discord.gg/z8sE2gnMNk)
 
@@ -367,13 +416,15 @@ Join our Discord community for discussions, support and collaboration for creati
 
 ## 📄 License
 
-This project is licensed under the **MIT License**. See the LICENSE file for details.
+This project is licensed under the **MIT License**. See the LICENSE file for
+details.
 
 ---
 
 ## 🙏 Acknowledgments
 
-- **Font Authors**: Thank you to all the original font creators whose work is included.
+- **Font Authors**: Thank you to all the original font creators whose work is
+  included.
 - **[Charm](https://charm.land)**: For the excellent TUI framework.
 - **Go Community**: For the robust standard library and tooling.
 

--- a/ansifonts/measure.go
+++ b/ansifonts/measure.go
@@ -1,0 +1,27 @@
+package ansifonts
+
+import (
+	"regexp"
+	"unicode/utf8"
+)
+
+// ANSI escape sequence regex for accurate stripping
+var ansiRegex = regexp.MustCompile(`\x1b\[[0-9;]*m`)
+
+// StripANSI removes ANSI escape sequences for accurate width calculation
+func StripANSI(s string) string {
+	return ansiRegex.ReplaceAllString(s, "")
+}
+
+// MeasureBlock returns the maximum width and total height of a text block.
+// Width is calculated using rune count after ANSI sequences are stripped.
+func MeasureBlock(lines []string) (w int, h int) {
+	h = len(lines)
+	for _, line := range lines {
+		lineWidth := utf8.RuneCountInString(StripANSI(line))
+		if lineWidth > w {
+			w = lineWidth
+		}
+	}
+	return w, h
+}

--- a/ansifonts/measure_test.go
+++ b/ansifonts/measure_test.go
@@ -1,0 +1,27 @@
+package ansifonts
+
+import "testing"
+
+func TestStripANSI(t *testing.T) {
+	input := "A\x1b[31mB\x1b[0mC"
+	got := StripANSI(input)
+	if got != "ABC" {
+		t.Fatalf("StripANSI() = %q, want %q", got, "ABC")
+	}
+}
+
+func TestMeasureBlockWithANSI(t *testing.T) {
+	lines := []string{
+		"hi",
+		"",
+		"\x1b[31mcolor\x1b[0m",
+	}
+
+	w, h := MeasureBlock(lines)
+	if w != 5 {
+		t.Fatalf("MeasureBlock() width = %d, want %d", w, 5)
+	}
+	if h != 3 {
+		t.Fatalf("MeasureBlock() height = %d, want %d", h, 3)
+	}
+}

--- a/ansifonts/render.go
+++ b/ansifonts/render.go
@@ -3,7 +3,6 @@ package ansifonts
 import (
 	"fmt"
 	"math"
-	"regexp"
 	"strings"
 	"unicode/utf8"
 )
@@ -84,7 +83,7 @@ func RenderTextWithFont(text string, fontData FontData, options RenderOptions) [
 
 		lineWidth := 0
 		for _, row := range lineRendered {
-			lineWidth = max(lineWidth, utf8.RuneCountInString(stripANSI(row)))
+			lineWidth = max(lineWidth, utf8.RuneCountInString(StripANSI(row)))
 		}
 
 		maxTextLineWidth = max(maxTextLineWidth, lineWidth)
@@ -119,11 +118,11 @@ func RenderTextWithFont(text string, fontData FontData, options RenderOptions) [
 	// Final pass to ensure all lines have the same width for consistent rendering
 	maxWidth := 0
 	for _, line := range allRenderedLines {
-		maxWidth = max(maxWidth, utf8.RuneCountInString(stripANSI(line)))
+		maxWidth = max(maxWidth, utf8.RuneCountInString(StripANSI(line)))
 	}
 
 	for i, line := range allRenderedLines {
-		lineWidth := utf8.RuneCountInString(stripANSI(line))
+		lineWidth := utf8.RuneCountInString(StripANSI(line))
 		if lineWidth < maxWidth {
 			allRenderedLines[i] = line + strings.Repeat(" ", maxWidth-lineWidth)
 		}
@@ -303,7 +302,7 @@ func applyAlignmentToTextLine(lineRendered []string, maxTextLineWidth int, align
 	// Find the actual width of this text line (use the widest row)
 	lineWidth := 0
 	for _, row := range lineRendered {
-		lineWidth = max(lineWidth, utf8.RuneCountInString(stripANSI(row)))
+		lineWidth = max(lineWidth, utf8.RuneCountInString(StripANSI(row)))
 	}
 
 	// If this line is already at max width, no alignment needed
@@ -328,7 +327,7 @@ func applyAlignmentToTextLine(lineRendered []string, maxTextLineWidth int, align
 	// Apply the same padding to all rows in this text line
 	alignedRows := make([]string, len(lineRendered))
 	for i, row := range lineRendered {
-		rowWidth := utf8.RuneCountInString(stripANSI(row))
+		rowWidth := utf8.RuneCountInString(StripANSI(row))
 
 		// Add left padding
 		alignedRow := strings.Repeat(" ", leftPadding) + row
@@ -344,14 +343,6 @@ func applyAlignmentToTextLine(lineRendered []string, maxTextLineWidth int, align
 	}
 
 	return alignedRows
-}
-
-// ANSI escape sequence regex for accurate stripping
-var ansiRegex = regexp.MustCompile(`\x1b\[[0-9;]*m`)
-
-// stripANSI removes ANSI escape sequences for accurate width calculation
-func stripANSI(s string) string {
-	return ansiRegex.ReplaceAllString(s, "")
 }
 
 // stripEmptyLines removes empty lines from both the top and bottom of rendered text

--- a/cmd/bit/main.go
+++ b/cmd/bit/main.go
@@ -271,9 +271,7 @@ func main() {
 		fontCache := make(map[string]*ansifonts.Font)
 		for i := 0; i < fitLimit; i++ {
 			candidate := candidates[i]
-			if fitShowDims {
-			fmt.Println(formatFitLine(i+1, candidate, fitWidth, fitHeight))
-		}
+			fmt.Println(formatFitLine(i+1, candidate, fitShowDims, fitWidth, fitHeight, fitPriority))
 
 			font, ok := fontCache[candidate.Font]
 			if !ok {
@@ -422,13 +420,71 @@ func scaleFactorFromIndex(scaleIndex int) (float64, bool) {
 	}
 }
 
-func formatFitLine(index int, candidate fit.Candidate,  targetW int, targetH int) string {
-	line := fmt.Sprintf("%2d. %s scale=%.2f  w=%d h=%d", index, candidate.Font, candidate.Scale, candidate.W, candidate.H)
+func formatFitLine(index int, candidate fit.Candidate, showDims bool, targetW int, targetH int, priority string) string {
+	fontLabel := ansiColor(candidate.Font, colorGreen)
+	line := fmt.Sprintf("%2d. %s scale=%.2f priority=%s", index, fontLabel, candidate.Scale, strings.ToLower(priority))
+	if !showDims {
+		return line
+	}
+
+	wLabel := fmt.Sprintf("w=%d", candidate.W)
+	hLabel := fmt.Sprintf("h=%d", candidate.H)
+	if targetW > 0 {
+		wLabel = colorizeIf(wLabel, candidate.W <= targetW, colorGreen, colorRed)
+	}
+	if targetH > 0 {
+		hLabel = colorizeIf(hLabel, candidate.H <= targetH, colorGreen, colorRed)
+	}
+	line += " " + wLabel + " " + hLabel
+
+	if targetW > 0 {
+		line += " " + ansiColor(fmt.Sprintf("target-w=%d", targetW), colorPastelBlue)
+	}
+	if targetH > 0 {
+		line += " " + ansiColor(fmt.Sprintf("target-h=%d", targetH), colorPastelBlue)
+	}
 	if targetW > 0 {
 		line += fmt.Sprintf(" dw=%d", candidate.DW)
 	}
 	if targetH > 0 {
 		line += fmt.Sprintf(" dh=%d", candidate.DH)
 	}
+
 	return line
+}
+
+const (
+	colorPastelBlue = "#7FB3FF"
+	colorGreen      = "#2ECC71"
+	colorRed        = "#FF6B6B"
+)
+
+func colorizeIf(value string, condition bool, trueColor string, falseColor string) string {
+	if condition {
+		return ansiColor(value, trueColor)
+	}
+	return ansiColor(value, falseColor)
+}
+
+func ansiColor(value string, hexColor string) string {
+	r, g, b, ok := parseHexColor(hexColor)
+	if !ok {
+		return value
+	}
+	return fmt.Sprintf("\x1b[38;2;%d;%d;%dm%s\x1b[0m", r, g, b, value)
+}
+
+func parseHexColor(hexColor string) (int, int, int, bool) {
+	trimmed := strings.TrimPrefix(hexColor, "#")
+	if len(trimmed) != 6 {
+		return 0, 0, 0, false
+	}
+	value, err := strconv.ParseUint(trimmed, 16, 32)
+	if err != nil {
+		return 0, 0, 0, false
+	}
+	r := int((value >> 16) & 0xFF)
+	g := int((value >> 8) & 0xFF)
+	b := int(value & 0xFF)
+	return r, g, b, true
 }

--- a/cmd/bit/main.go
+++ b/cmd/bit/main.go
@@ -33,12 +33,11 @@ func main() {
 	var loadFontPath string
 	var fitFonts string
 	var fitScales string
-	var targetW int
-	var targetH int
-	var priority string
-	var limit int
-	var showDims bool
-	var noPreview bool
+	var fitWidth int
+	var fitHeight int
+	var fitPriority string
+	var fitLimit int
+	var fitShowDims bool
 
 	flag.StringVar(&fontName, "font", "", "Font name to use (default: first available font)")
 	flag.StringVar(&textColor, "color", "", "Text color: ANSI code (31) or hex (#FF0000)")
@@ -56,14 +55,13 @@ func main() {
 	flag.BoolVar(&list, "list", false, "List all available fonts")
 	flag.BoolVar(&version, "version", false, "Show version information")
 	flag.StringVar(&loadFontPath, "load", "", "Path to a custom font file (.bit) OR a directory of fonts")
-	flag.StringVar(&fitFonts, "fonts", "", "CSV list of fonts to test in fit mode")
-	flag.StringVar(&fitScales, "scales", "", "CSV list of scale factors to test in fit mode")
-	flag.IntVar(&targetW, "target-w", 0, "Target width for fit mode")
-	flag.IntVar(&targetH, "target-h", 0, "Target height for fit mode")
-	flag.StringVar(&priority, "priority", "width", "Fit priority: width or height")
-	flag.IntVar(&limit, "limit", 10, "Max results to show in fit mode")
-	flag.BoolVar(&showDims, "show-dims", false, "Show measured dimensions in fit mode")
-	flag.BoolVar(&noPreview, "no-preview", false, "Disable preview render in fit mode")
+	flag.StringVar(&fitFonts, "fit-fonts", "", "CSV list of fonts to test in fit mode")
+	flag.StringVar(&fitScales, "fit-scales", "", "CSV list of scale factors (e.g. 1.0,2.0) or scale steps (-1,0,1,2)")
+	flag.IntVar(&fitWidth, "fit-width", 0, "Target width for fit mode")
+	flag.IntVar(&fitHeight, "fit-height", 0, "Target height for fit mode")
+	flag.StringVar(&fitPriority, "fit-priority", "width", "Fit priority: width or height")
+	flag.IntVar(&fitLimit, "fit-limit", 30, "Max results to show in fit mode")
+	flag.BoolVar(&fitShowDims, "fit-show-dims", false, "Show measured dimensions in fit mode")
 
 	flag.Usage = func() {
 		fmt.Fprintf(os.Stderr, "Bit - Terminal ANSI Logo Designer & Font Library\n\n")
@@ -87,12 +85,12 @@ func main() {
 		fmt.Fprintf(os.Stderr, "  bit -font pressstart -color 32 -shadow \"Shadow\"        # With shadow\n")
 		fmt.Fprintf(os.Stderr, "  bit -load ./myfont.bit \"Custom\"                        # Load custom font file\n")
 		fmt.Fprintf(os.Stderr, "  bit -load ./fonts/ -list                               # Load custom font directory\n")
-		fmt.Fprintf(os.Stderr, "  bit -target-w 40 -target-h 10 \"Hello\"                  # Fit mode\n")
+		fmt.Fprintf(os.Stderr, "  bit -fit-width 40 -fit-height 10 -fit-show-dims \"Hello\"  # Fit mode\n")
 	}
 
 	flag.Parse()
 
-	fitMode := targetW > 0 || targetH > 0
+	fitMode := fitWidth > 0 || fitHeight > 0
 
 	// Process custom font loading BEFORE other operations
 	if loadFontPath != "" {
@@ -175,17 +173,8 @@ func main() {
 	}
 
 	// Convert scaleInt to actual scale factor
-	var scale float64
-	switch scaleInt {
-	case -1:
-		scale = 0.5 // 0.5x
-	case 0:
-		scale = 1.0 // 1x
-	case 1:
-		scale = 2.0 // 2x
-	case 2:
-		scale = 4.0 // 4x
-	default:
+	scale, ok := scaleFactorFromIndex(scaleInt)
+	if !ok {
 		scale = 1.0 // Default to 1x if invalid value provided
 		fmt.Fprintf(os.Stderr, "Warning: Invalid scale value '%d', using default scale (1x)\n", scaleInt)
 	}
@@ -260,7 +249,7 @@ func main() {
 			os.Exit(1)
 		}
 
-		candidates, err := fit.FindBest(text, fontsToUse, scalesToUse, options, targetW, targetH, fit.Priority(priority))
+		candidates, err := fit.FindBest(text, fontsToUse, scalesToUse, options, fitWidth, fitHeight, fit.Priority(fitPriority))
 		if err != nil {
 			if missingErr, ok := err.(*fit.MissingFontError); ok {
 				fmt.Fprintf(os.Stderr, "Warning: skipped missing fonts: %s\n", strings.Join(missingErr.Missing, ", "))
@@ -275,35 +264,37 @@ func main() {
 			os.Exit(1)
 		}
 
-		if limit <= 0 || limit > len(candidates) {
-			limit = len(candidates)
+		if fitLimit <= 0 || fitLimit > len(candidates) {
+			fitLimit = len(candidates)
 		}
 
-		fmt.Println("Fit results:")
-		for i := 0; i < limit; i++ {
+		fontCache := make(map[string]*ansifonts.Font)
+		for i := 0; i < fitLimit; i++ {
 			candidate := candidates[i]
-			if showDims {
-				fmt.Printf("%2d. %s scale=%.2f %dx%d dw=%d dh=%d\n", i+1, candidate.Font, candidate.Scale, candidate.W, candidate.H, candidate.DW, candidate.DH)
-				continue
+			if fitShowDims {
+			fmt.Println(formatFitLine(i+1, candidate, fitWidth, fitHeight))
+		}
+
+			font, ok := fontCache[candidate.Font]
+			if !ok {
+				loadedFont, err := ansifonts.LoadFont(candidate.Font)
+				if err != nil {
+					fmt.Fprintf(os.Stderr, "Error loading font '%s': %v\n", candidate.Font, err)
+					os.Exit(1)
+				}
+				font = loadedFont
+				fontCache[candidate.Font] = font
 			}
-			fmt.Printf("%2d. %s scale=%.2f dw=%d dh=%d\n", i+1, candidate.Font, candidate.Scale, candidate.DW, candidate.DH)
-		}
 
-		if noPreview {
-			return
-		}
-
-		best := candidates[0]
-		bestFont, err := ansifonts.LoadFont(best.Font)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error loading font '%s': %v\n", best.Font, err)
-			os.Exit(1)
-		}
-		options.ScaleFactor = best.Scale
-		fmt.Println()
-		preview := ansifonts.RenderTextWithOptions(text, bestFont, options)
-		for _, line := range preview {
-			fmt.Println(line)
+			previewOptions := options
+			previewOptions.ScaleFactor = candidate.Scale
+			preview := ansifonts.RenderTextWithOptions(text, font, previewOptions)
+			for _, line := range preview {
+				fmt.Println(line)
+			}
+			if i != fitLimit-1 {
+				fmt.Println()
+			}
 		}
 		return
 	}
@@ -358,9 +349,9 @@ func resolveFitScales(scalesCSV string, fallbackScale float64) ([]float64, error
 
 	values := make([]float64, 0, len(parts))
 	for _, raw := range parts {
-		value, err := strconv.ParseFloat(raw, 64)
+		value, err := parseScaleValue(raw)
 		if err != nil {
-			return nil, fmt.Errorf("invalid scale %q", raw)
+			return nil, err
 		}
 		values = append(values, value)
 	}
@@ -378,4 +369,66 @@ func splitCSV(value string) []string {
 		results = append(results, trimmed)
 	}
 	return results
+}
+
+func parseScaleValue(raw string) (float64, error) {
+	if isScaleIndex(raw) {
+		value, ok := scaleFactorFromIndex(mustAtoi(raw))
+		if !ok {
+			return 0, fmt.Errorf("invalid scale index %q", raw)
+		}
+		return value, nil
+	}
+
+	value, err := strconv.ParseFloat(raw, 64)
+	if err != nil {
+		return 0, fmt.Errorf("invalid scale %q", raw)
+	}
+	if value < ansifonts.MinScaleFactor || value > ansifonts.MaxScaleFactor {
+		return 0, fmt.Errorf("scale %q out of range", raw)
+	}
+	return value, nil
+}
+
+func isScaleIndex(raw string) bool {
+	if strings.ContainsAny(raw, ".eE") {
+		return false
+	}
+	value, err := strconv.Atoi(raw)
+	if err != nil {
+		return false
+	}
+	_, ok := scaleFactorFromIndex(value)
+	return ok
+}
+
+func mustAtoi(raw string) int {
+	value, _ := strconv.Atoi(raw)
+	return value
+}
+
+func scaleFactorFromIndex(scaleIndex int) (float64, bool) {
+	switch scaleIndex {
+	case -1:
+		return 0.5, true
+	case 0:
+		return 1.0, true
+	case 1:
+		return 2.0, true
+	case 2:
+		return 4.0, true
+	default:
+		return 0, false
+	}
+}
+
+func formatFitLine(index int, candidate fit.Candidate,  targetW int, targetH int) string {
+	line := fmt.Sprintf("%2d. %s scale=%.2f  w=%d h=%d", index, candidate.Font, candidate.Scale, candidate.W, candidate.H)
+	if targetW > 0 {
+		line += fmt.Sprintf(" dw=%d", candidate.DW)
+	}
+	if targetH > 0 {
+		line += fmt.Sprintf(" dh=%d", candidate.DH)
+	}
+	return line
 }

--- a/cmd/bit/main.go
+++ b/cmd/bit/main.go
@@ -284,13 +284,17 @@ func main() {
 				fontCache[candidate.Font] = font
 			}
 
-			previewOptions := options
-			previewOptions.ScaleFactor = candidate.Scale
-			preview := ansifonts.RenderTextWithOptions(text, font, previewOptions)
-			for _, line := range preview {
-				fmt.Println(line)
+			printedPreview := false
+			if candidate.Fits {
+				previewOptions := options
+				previewOptions.ScaleFactor = candidate.Scale
+				preview := ansifonts.RenderTextWithOptions(text, font, previewOptions)
+				for _, line := range preview {
+					fmt.Println(line)
+				}
+				printedPreview = true
 			}
-			if i != fitLimit-1 {
+			if printedPreview && i != fitLimit-1 {
 				fmt.Println()
 			}
 		}
@@ -429,11 +433,12 @@ func formatFitLine(index int, candidate fit.Candidate, showDims bool, targetW in
 
 	wLabel := fmt.Sprintf("w=%d", candidate.W)
 	hLabel := fmt.Sprintf("h=%d", candidate.H)
-	if targetW > 0 {
-		wLabel = colorizeIf(wLabel, candidate.W <= targetW, colorGreen, colorRed)
+	priorityValue := strings.ToLower(priority)
+	if targetW > 0 && priorityValue == string(fit.PriorityWidth) {
+		wLabel = colorizeIf(wLabel, candidate.Fits, colorGreen, colorRed)
 	}
-	if targetH > 0 {
-		hLabel = colorizeIf(hLabel, candidate.H <= targetH, colorGreen, colorRed)
+	if targetH > 0 && priorityValue == string(fit.PriorityHeight) {
+		hLabel = colorizeIf(hLabel, candidate.Fits, colorGreen, colorRed)
 	}
 	line += " " + wLabel + " " + hLabel
 

--- a/cmd/bit/main.go
+++ b/cmd/bit/main.go
@@ -273,7 +273,9 @@ func main() {
 		fontCache := make(map[string]*ansifonts.Font)
 		for i := 0; i < fitLimit; i++ {
 			candidate := candidates[i]
-			fmt.Println(formatFitLine(i+1, candidate, fitShowDims, fitWidth, fitHeight, fitPriority))
+			if fitShowDims {
+				fmt.Println(formatFitLine(i+1, candidate, fitWidth, fitHeight, fitPriority))
+			}
 
 			font, ok := fontCache[candidate.Font]
 			if !ok {
@@ -413,13 +415,9 @@ func scaleFactorFromIndex(scaleIndex int) (float64, bool) {
 	}
 }
 
-func formatFitLine(index int, candidate fit.Candidate, showDims bool, targetW int, targetH int, priority string) string {
+func formatFitLine(index int, candidate fit.Candidate, targetW int, targetH int, priority string) string {
 	fontLabel := ansiColor(candidate.Font, colorGreen)
 	line := fmt.Sprintf("%2d. %s scale=%d priority=%s", index, fontLabel, candidate.ScaleIndex, strings.ToLower(priority))
-	if !showDims {
-		return line
-	}
-
 	wLabel := fmt.Sprintf("w=%d", candidate.W)
 	hLabel := fmt.Sprintf("h=%d", candidate.H)
 	priorityValue := strings.ToLower(priority)

--- a/cmd/bit/main.go
+++ b/cmd/bit/main.go
@@ -56,7 +56,7 @@ func main() {
 	flag.BoolVar(&version, "version", false, "Show version information")
 	flag.StringVar(&loadFontPath, "load", "", "Path to a custom font file (.bit) OR a directory of fonts")
 	flag.StringVar(&fitFonts, "fit-fonts", "", "CSV list of fonts to test in fit mode")
-	flag.StringVar(&fitScales, "fit-scales", "", "CSV list of scale factors (e.g. 1.0,2.0) or scale steps (-1,0,1,2)")
+	flag.StringVar(&fitScales, "fit-scales", "", "CSV list of scale indices (-1,0,1,2)")
 	flag.IntVar(&fitWidth, "fit-width", 0, "Target width for fit mode")
 	flag.IntVar(&fitHeight, "fit-height", 0, "Target height for fit mode")
 	flag.StringVar(&fitPriority, "fit-priority", "width", "Fit priority: width or height")
@@ -173,8 +173,10 @@ func main() {
 	}
 
 	// Convert scaleInt to actual scale factor
+	scaleIndex := scaleInt
 	scale, ok := scaleFactorFromIndex(scaleInt)
 	if !ok {
+		scaleIndex = 0
 		scale = 1.0 // Default to 1x if invalid value provided
 		fmt.Fprintf(os.Stderr, "Warning: Invalid scale value '%d', using default scale (1x)\n", scaleInt)
 	}
@@ -243,7 +245,7 @@ func main() {
 			os.Exit(1)
 		}
 
-		scalesToUse, err := resolveFitScales(fitScales, scale)
+		scalesToUse, err := resolveFitScales(fitScales, scaleIndex)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error parsing scales: %v\n", err)
 			os.Exit(1)
@@ -287,7 +289,11 @@ func main() {
 			printedPreview := false
 			if candidate.Fits {
 				previewOptions := options
-				previewOptions.ScaleFactor = candidate.Scale
+				previewScale, ok := scaleFactorFromIndex(candidate.ScaleIndex)
+				if !ok {
+					previewScale = 1.0
+				}
+				previewOptions.ScaleFactor = previewScale
 				preview := ansifonts.RenderTextWithOptions(text, font, previewOptions)
 				for _, line := range preview {
 					fmt.Println(line)
@@ -339,9 +345,13 @@ func resolveFitFonts(fontsCSV string, fallbackFont string) ([]string, error) {
 	return ansifonts.ListFonts()
 }
 
-func resolveFitScales(scalesCSV string, fallbackScale float64) ([]float64, error) {
+func resolveFitScales(scalesCSV string, fallbackScaleIndex int) ([]fit.ScaleOption, error) {
 	if scalesCSV == "" {
-		return []float64{fallbackScale}, nil
+		factor, ok := scaleFactorFromIndex(fallbackScaleIndex)
+		if !ok {
+			return nil, fmt.Errorf("invalid scale index %d", fallbackScaleIndex)
+		}
+		return []fit.ScaleOption{{Index: fallbackScaleIndex, Factor: factor}}, nil
 	}
 
 	parts := splitCSV(scalesCSV)
@@ -349,13 +359,14 @@ func resolveFitScales(scalesCSV string, fallbackScale float64) ([]float64, error
 		return nil, fmt.Errorf("no scales provided")
 	}
 
-	values := make([]float64, 0, len(parts))
+	values := make([]fit.ScaleOption, 0, len(parts))
 	for _, raw := range parts {
-		value, err := parseScaleValue(raw)
+		scaleIndex, err := parseScaleIndex(raw)
 		if err != nil {
 			return nil, err
 		}
-		values = append(values, value)
+		factor, _ := scaleFactorFromIndex(scaleIndex)
+		values = append(values, fit.ScaleOption{Index: scaleIndex, Factor: factor})
 	}
 	return values, nil
 }
@@ -373,40 +384,18 @@ func splitCSV(value string) []string {
 	return results
 }
 
-func parseScaleValue(raw string) (float64, error) {
-	if isScaleIndex(raw) {
-		value, ok := scaleFactorFromIndex(mustAtoi(raw))
-		if !ok {
-			return 0, fmt.Errorf("invalid scale index %q", raw)
-		}
-		return value, nil
-	}
-
-	value, err := strconv.ParseFloat(raw, 64)
-	if err != nil {
-		return 0, fmt.Errorf("invalid scale %q", raw)
-	}
-	if value < ansifonts.MinScaleFactor || value > ansifonts.MaxScaleFactor {
-		return 0, fmt.Errorf("scale %q out of range", raw)
-	}
-	return value, nil
-}
-
-func isScaleIndex(raw string) bool {
+func parseScaleIndex(raw string) (int, error) {
 	if strings.ContainsAny(raw, ".eE") {
-		return false
+		return 0, fmt.Errorf("invalid scale index %q", raw)
 	}
 	value, err := strconv.Atoi(raw)
 	if err != nil {
-		return false
+		return 0, fmt.Errorf("invalid scale index %q", raw)
 	}
-	_, ok := scaleFactorFromIndex(value)
-	return ok
-}
-
-func mustAtoi(raw string) int {
-	value, _ := strconv.Atoi(raw)
-	return value
+	if _, ok := scaleFactorFromIndex(value); !ok {
+		return 0, fmt.Errorf("invalid scale index %q", raw)
+	}
+	return value, nil
 }
 
 func scaleFactorFromIndex(scaleIndex int) (float64, bool) {
@@ -426,7 +415,7 @@ func scaleFactorFromIndex(scaleIndex int) (float64, bool) {
 
 func formatFitLine(index int, candidate fit.Candidate, showDims bool, targetW int, targetH int, priority string) string {
 	fontLabel := ansiColor(candidate.Font, colorGreen)
-	line := fmt.Sprintf("%2d. %s scale=%.2f priority=%s", index, fontLabel, candidate.Scale, strings.ToLower(priority))
+	line := fmt.Sprintf("%2d. %s scale=%d priority=%s", index, fontLabel, candidate.ScaleIndex, strings.ToLower(priority))
 	if !showDims {
 		return line
 	}

--- a/cmd/bit/main.go
+++ b/cmd/bit/main.go
@@ -4,10 +4,12 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"strconv"
 	"strings"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/superstarryeyes/bit/ansifonts"
+	"github.com/superstarryeyes/bit/internal/fit"
 	"github.com/superstarryeyes/bit/internal/ui"
 )
 
@@ -29,6 +31,14 @@ func main() {
 	var list bool
 	var version bool
 	var loadFontPath string
+	var fitFonts string
+	var fitScales string
+	var targetW int
+	var targetH int
+	var priority string
+	var limit int
+	var showDims bool
+	var noPreview bool
 
 	flag.StringVar(&fontName, "font", "", "Font name to use (default: first available font)")
 	flag.StringVar(&textColor, "color", "", "Text color: ANSI code (31) or hex (#FF0000)")
@@ -46,6 +56,14 @@ func main() {
 	flag.BoolVar(&list, "list", false, "List all available fonts")
 	flag.BoolVar(&version, "version", false, "Show version information")
 	flag.StringVar(&loadFontPath, "load", "", "Path to a custom font file (.bit) OR a directory of fonts")
+	flag.StringVar(&fitFonts, "fonts", "", "CSV list of fonts to test in fit mode")
+	flag.StringVar(&fitScales, "scales", "", "CSV list of scale factors to test in fit mode")
+	flag.IntVar(&targetW, "target-w", 0, "Target width for fit mode")
+	flag.IntVar(&targetH, "target-h", 0, "Target height for fit mode")
+	flag.StringVar(&priority, "priority", "width", "Fit priority: width or height")
+	flag.IntVar(&limit, "limit", 10, "Max results to show in fit mode")
+	flag.BoolVar(&showDims, "show-dims", false, "Show measured dimensions in fit mode")
+	flag.BoolVar(&noPreview, "no-preview", false, "Disable preview render in fit mode")
 
 	flag.Usage = func() {
 		fmt.Fprintf(os.Stderr, "Bit - Terminal ANSI Logo Designer & Font Library\n\n")
@@ -69,9 +87,12 @@ func main() {
 		fmt.Fprintf(os.Stderr, "  bit -font pressstart -color 32 -shadow \"Shadow\"        # With shadow\n")
 		fmt.Fprintf(os.Stderr, "  bit -load ./myfont.bit \"Custom\"                        # Load custom font file\n")
 		fmt.Fprintf(os.Stderr, "  bit -load ./fonts/ -list                               # Load custom font directory\n")
+		fmt.Fprintf(os.Stderr, "  bit -target-w 40 -target-h 10 \"Hello\"                  # Fit mode\n")
 	}
 
 	flag.Parse()
+
+	fitMode := targetW > 0 || targetH > 0
 
 	// Process custom font loading BEFORE other operations
 	if loadFontPath != "" {
@@ -107,7 +128,7 @@ func main() {
 	}
 
 	// If no arguments provided, start interactive UI
-	if flag.NArg() == 0 && !list && !version {
+	if flag.NArg() == 0 && !list && !version && !fitMode {
 		m, err := ui.InitialModel()
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error initializing application: %v\n", err)
@@ -130,27 +151,6 @@ func main() {
 
 	// Replace literal \n with actual newlines
 	text = strings.ReplaceAll(text, "\\n", "\n")
-
-	// If no font specified, use the first available font
-	if fontName == "" {
-		fonts, err := ansifonts.ListFonts()
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error listing fonts: %v\n", err)
-			os.Exit(1)
-		}
-		if len(fonts) == 0 {
-			fmt.Fprintf(os.Stderr, "No fonts available\n")
-			os.Exit(1)
-		}
-		fontName = fonts[0]
-	}
-
-	// Load the font
-	font, err := ansifonts.LoadFont(fontName)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error loading font '%s': %v\n", fontName, err)
-		os.Exit(1)
-	}
 
 	// Helper function to parse color (ANSI code or hex)
 	parseColor := func(colorInput string, defaultColor string) string {
@@ -247,9 +247,135 @@ func main() {
 		options.ShadowStyle = ansifonts.ShadowStyle(shadowStyle)
 	}
 
+	if fitMode {
+		fontsToUse, err := resolveFitFonts(fitFonts, fontName)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error resolving fonts: %v\n", err)
+			os.Exit(1)
+		}
+
+		scalesToUse, err := resolveFitScales(fitScales, scale)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error parsing scales: %v\n", err)
+			os.Exit(1)
+		}
+
+		candidates, err := fit.FindBest(text, fontsToUse, scalesToUse, options, targetW, targetH, fit.Priority(priority))
+		if err != nil {
+			if missingErr, ok := err.(*fit.MissingFontError); ok {
+				fmt.Fprintf(os.Stderr, "Warning: skipped missing fonts: %s\n", strings.Join(missingErr.Missing, ", "))
+			} else {
+				fmt.Fprintf(os.Stderr, "Error running fit: %v\n", err)
+				os.Exit(1)
+			}
+		}
+
+		if len(candidates) == 0 {
+			fmt.Fprintln(os.Stderr, "No fit candidates found")
+			os.Exit(1)
+		}
+
+		if limit <= 0 || limit > len(candidates) {
+			limit = len(candidates)
+		}
+
+		fmt.Println("Fit results:")
+		for i := 0; i < limit; i++ {
+			candidate := candidates[i]
+			if showDims {
+				fmt.Printf("%2d. %s scale=%.2f %dx%d dw=%d dh=%d\n", i+1, candidate.Font, candidate.Scale, candidate.W, candidate.H, candidate.DW, candidate.DH)
+				continue
+			}
+			fmt.Printf("%2d. %s scale=%.2f dw=%d dh=%d\n", i+1, candidate.Font, candidate.Scale, candidate.DW, candidate.DH)
+		}
+
+		if noPreview {
+			return
+		}
+
+		best := candidates[0]
+		bestFont, err := ansifonts.LoadFont(best.Font)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error loading font '%s': %v\n", best.Font, err)
+			os.Exit(1)
+		}
+		options.ScaleFactor = best.Scale
+		fmt.Println()
+		preview := ansifonts.RenderTextWithOptions(text, bestFont, options)
+		for _, line := range preview {
+			fmt.Println(line)
+		}
+		return
+	}
+
+	// If no font specified, use the first available font
+	if fontName == "" {
+		fonts, err := ansifonts.ListFonts()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error listing fonts: %v\n", err)
+			os.Exit(1)
+		}
+		if len(fonts) == 0 {
+			fmt.Fprintf(os.Stderr, "No fonts available\n")
+			os.Exit(1)
+		}
+		fontName = fonts[0]
+	}
+
+	// Load the font
+	font, err := ansifonts.LoadFont(fontName)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error loading font '%s': %v\n", fontName, err)
+		os.Exit(1)
+	}
+
 	// Render and print
 	rendered := ansifonts.RenderTextWithOptions(text, font, options)
 	for _, line := range rendered {
 		fmt.Println(line)
 	}
+}
+
+func resolveFitFonts(fontsCSV string, fallbackFont string) ([]string, error) {
+	if fontsCSV != "" {
+		return splitCSV(fontsCSV), nil
+	}
+	if fallbackFont != "" {
+		return []string{fallbackFont}, nil
+	}
+	return ansifonts.ListFonts()
+}
+
+func resolveFitScales(scalesCSV string, fallbackScale float64) ([]float64, error) {
+	if scalesCSV == "" {
+		return []float64{fallbackScale}, nil
+	}
+
+	parts := splitCSV(scalesCSV)
+	if len(parts) == 0 {
+		return nil, fmt.Errorf("no scales provided")
+	}
+
+	values := make([]float64, 0, len(parts))
+	for _, raw := range parts {
+		value, err := strconv.ParseFloat(raw, 64)
+		if err != nil {
+			return nil, fmt.Errorf("invalid scale %q", raw)
+		}
+		values = append(values, value)
+	}
+	return values, nil
+}
+
+func splitCSV(value string) []string {
+	parts := strings.Split(value, ",")
+	results := make([]string, 0, len(parts))
+	for _, part := range parts {
+		trimmed := strings.TrimSpace(part)
+		if trimmed == "" {
+			continue
+		}
+		results = append(results, trimmed)
+	}
+	return results
 }

--- a/internal/fit/fit.go
+++ b/internal/fit/fit.go
@@ -10,13 +10,19 @@ import (
 
 // Candidate represents a font and scale candidate with its measured dimensions.
 type Candidate struct {
-	Font  string
-	Scale float64
-	W     int
-	H     int
-	DW    int
-	DH    int
-	Fits  bool
+	Font       string
+	ScaleIndex int
+	W          int
+	H          int
+	DW         int
+	DH         int
+	Fits       bool
+}
+
+// ScaleOption represents a scale index and its factor.
+type ScaleOption struct {
+	Index  int
+	Factor float64
 }
 
 // Priority indicates which dimension should be prioritized in sorting.
@@ -37,7 +43,7 @@ func (err *MissingFontError) Error() string {
 }
 
 // FindBest renders text with each font/scale, measures it, and returns sorted candidates.
-func FindBest(text string, fonts []string, scales []float64, baseOptions ansifonts.RenderOptions, targetW int, targetH int, priority Priority) ([]Candidate, error) {
+func FindBest(text string, fonts []string, scales []ScaleOption, baseOptions ansifonts.RenderOptions, targetW int, targetH int, priority Priority) ([]Candidate, error) {
 	if len(fonts) == 0 {
 		return nil, fmt.Errorf("no fonts provided")
 	}
@@ -68,17 +74,17 @@ func FindBest(text string, fonts []string, scales []float64, baseOptions ansifon
 
 		for _, scale := range scales {
 			options := baseOptions
-			options.ScaleFactor = scale
+			options.ScaleFactor = scale.Factor
 			rendered := ansifonts.RenderTextWithOptions(text, fontObj, options)
 			w, h := ansifonts.MeasureBlock(rendered)
 			candidate := Candidate{
-				Font:  fontObj.Name,
-				Scale: scale,
-				W:     w,
-				H:     h,
-				DW:    distance(targetW, w),
-				DH:    distance(targetH, h),
-				Fits:  fitsWithin(targetW, targetH, w, h),
+				Font:       fontObj.Name,
+				ScaleIndex: scale.Index,
+				W:          w,
+				H:          h,
+				DW:         distance(targetW, w),
+				DH:         distance(targetH, h),
+				Fits:       fitsWithin(targetW, targetH, w, h),
 			}
 			candidates = append(candidates, candidate)
 		}
@@ -157,7 +163,10 @@ func sortCandidates(candidates []Candidate, priority Priority) {
 		if a.Font != b.Font {
 			return a.Font < b.Font
 		}
-		return a.Scale < b.Scale
+		if a.ScaleIndex != b.ScaleIndex {
+			return a.ScaleIndex > b.ScaleIndex
+		}
+		return false
 	})
 }
 

--- a/internal/fit/fit.go
+++ b/internal/fit/fit.go
@@ -16,6 +16,7 @@ type Candidate struct {
 	H     int
 	DW    int
 	DH    int
+	Fits  bool
 }
 
 // Priority indicates which dimension should be prioritized in sorting.
@@ -77,9 +78,7 @@ func FindBest(text string, fonts []string, scales []float64, baseOptions ansifon
 				H:     h,
 				DW:    distance(targetW, w),
 				DH:    distance(targetH, h),
-			}
-			if candidate.DW < 0 || candidate.DH < 0 {
-				continue // Skip candidates that exceed target dimensions
+				Fits:  fitsWithin(targetW, targetH, w, h),
 			}
 			candidates = append(candidates, candidate)
 		}
@@ -117,19 +116,41 @@ func sortCandidates(candidates []Candidate, priority Priority) {
 		a := candidates[i]
 		b := candidates[j]
 
+		if a.Fits != b.Fits {
+			return a.Fits
+		}
+
 		if priority == PriorityHeight {
-			if a.DH != b.DH {
-				return a.DH < b.DH
-			}
-			if a.DW != b.DW {
-				return a.DW < b.DW
+			if a.Fits {
+				if a.DH != b.DH {
+					return a.DH < b.DH
+				}
+				if a.DW != b.DW {
+					return a.DW < b.DW
+				}
+			} else {
+				if absInt(a.DH) != absInt(b.DH) {
+					return absInt(a.DH) < absInt(b.DH)
+				}
+				if absInt(a.DW) != absInt(b.DW) {
+					return absInt(a.DW) < absInt(b.DW)
+				}
 			}
 		} else {
-			if a.DW != b.DW {
-				return a.DW < b.DW
-			}
-			if a.DH != b.DH {
-				return a.DH < b.DH
+			if a.Fits {
+				if a.DW != b.DW {
+					return a.DW < b.DW
+				}
+				if a.DH != b.DH {
+					return a.DH < b.DH
+				}
+			} else {
+				if absInt(a.DW) != absInt(b.DW) {
+					return absInt(a.DW) < absInt(b.DW)
+				}
+				if absInt(a.DH) != absInt(b.DH) {
+					return absInt(a.DH) < absInt(b.DH)
+				}
 			}
 		}
 
@@ -144,5 +165,22 @@ func distance(target int, actual int) int {
 	if target == 0 {
 		return 0
 	}
-	return  target -actual 
+	return target - actual
+}
+
+func fitsWithin(targetW int, targetH int, width int, height int) bool {
+	if targetW > 0 && width > targetW {
+		return false
+	}
+	if targetH > 0 && height > targetH {
+		return false
+	}
+	return true
+}
+
+func absInt(value int) int {
+	if value < 0 {
+		return -value
+	}
+	return value
 }

--- a/internal/fit/fit.go
+++ b/internal/fit/fit.go
@@ -1,0 +1,148 @@
+package fit
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/superstarryeyes/bit/ansifonts"
+)
+
+// Candidate represents a font and scale candidate with its measured dimensions.
+type Candidate struct {
+	Font  string
+	Scale float64
+	W     int
+	H     int
+	DW    int
+	DH    int
+}
+
+// Priority indicates which dimension should be prioritized in sorting.
+type Priority string
+
+const (
+	PriorityWidth  Priority = "width"
+	PriorityHeight Priority = "height"
+)
+
+// MissingFontError reports fonts that could not be loaded.
+type MissingFontError struct {
+	Missing []string
+}
+
+func (err *MissingFontError) Error() string {
+	return fmt.Sprintf("failed to load %d font(s): %s", len(err.Missing), strings.Join(err.Missing, ", "))
+}
+
+// FindBest renders text with each font/scale, measures it, and returns sorted candidates.
+func FindBest(text string, fonts []string, scales []float64, baseOptions ansifonts.RenderOptions, targetW int, targetH int, priority Priority) ([]Candidate, error) {
+	if len(fonts) == 0 {
+		return nil, fmt.Errorf("no fonts provided")
+	}
+	if len(scales) == 0 {
+		return nil, fmt.Errorf("no scales provided")
+	}
+
+	normalizedPriority, err := normalizePriority(priority)
+	if err != nil {
+		return nil, err
+	}
+
+	fontCache := make(map[string]*ansifonts.Font, len(fonts))
+	var candidates []Candidate
+	var missingFonts []string
+
+	for _, fontName := range fonts {
+		fontObj, ok := fontCache[fontName]
+		if !ok {
+			loadedFont, loadErr := ansifonts.LoadFont(fontName)
+			if loadErr != nil {
+				missingFonts = append(missingFonts, fontName)
+				continue
+			}
+			fontCache[fontName] = loadedFont
+			fontObj = loadedFont
+		}
+
+		for _, scale := range scales {
+			options := baseOptions
+			options.ScaleFactor = scale
+			rendered := ansifonts.RenderTextWithOptions(text, fontObj, options)
+			w, h := ansifonts.MeasureBlock(rendered)
+			candidate := Candidate{
+				Font:  fontObj.Name,
+				Scale: scale,
+				W:     w,
+				H:     h,
+				DW:    distance(targetW, w),
+				DH:    distance(targetH, h),
+			}
+			candidates = append(candidates, candidate)
+		}
+	}
+
+	if len(candidates) == 0 {
+		if len(missingFonts) > 0 {
+			return nil, &MissingFontError{Missing: missingFonts}
+		}
+		return nil, fmt.Errorf("no candidates generated")
+	}
+
+	sortCandidates(candidates, normalizedPriority)
+
+	if len(missingFonts) > 0 {
+		return candidates, &MissingFontError{Missing: missingFonts}
+	}
+
+	return candidates, nil
+}
+
+func normalizePriority(priority Priority) (Priority, error) {
+	switch strings.ToLower(string(priority)) {
+	case "", string(PriorityWidth):
+		return PriorityWidth, nil
+	case string(PriorityHeight):
+		return PriorityHeight, nil
+	default:
+		return "", fmt.Errorf("invalid priority: %s", priority)
+	}
+}
+
+func sortCandidates(candidates []Candidate, priority Priority) {
+	sort.SliceStable(candidates, func(i, j int) bool {
+		a := candidates[i]
+		b := candidates[j]
+
+		if priority == PriorityHeight {
+			if a.DH != b.DH {
+				return a.DH < b.DH
+			}
+			if a.DW != b.DW {
+				return a.DW < b.DW
+			}
+		} else {
+			if a.DW != b.DW {
+				return a.DW < b.DW
+			}
+			if a.DH != b.DH {
+				return a.DH < b.DH
+			}
+		}
+
+		if a.Font != b.Font {
+			return a.Font < b.Font
+		}
+		return a.Scale < b.Scale
+	})
+}
+
+func distance(target int, actual int) int {
+	if target == 0 {
+		return 0
+	}
+	if actual >= target {
+		return actual - target
+	}
+	return target - actual
+}

--- a/internal/fit/fit.go
+++ b/internal/fit/fit.go
@@ -78,6 +78,9 @@ func FindBest(text string, fonts []string, scales []float64, baseOptions ansifon
 				DW:    distance(targetW, w),
 				DH:    distance(targetH, h),
 			}
+			if candidate.DW < 0 || candidate.DH < 0 {
+				continue // Skip candidates that exceed target dimensions
+			}
 			candidates = append(candidates, candidate)
 		}
 	}
@@ -141,8 +144,5 @@ func distance(target int, actual int) int {
 	if target == 0 {
 		return 0
 	}
-	if actual >= target {
-		return actual - target
-	}
-	return target - actual
+	return  target -actual 
 }

--- a/internal/fit/fit_test.go
+++ b/internal/fit/fit_test.go
@@ -7,19 +7,19 @@ import (
 
 func TestSortCandidatesWidthPriority(t *testing.T) {
 	candidates := []Candidate{
-		{Font: "b", Scale: 1, DW: 1, DH: 4},
-		{Font: "a", Scale: 2, DW: 1, DH: 2},
-		{Font: "a", Scale: 1, DW: 1, DH: 2},
-		{Font: "c", Scale: 1, DW: 0, DH: 7},
+		{Font: "b", Scale: 1, DW: 1, DH: 4, Fits: true},
+		{Font: "a", Scale: 2, DW: 1, DH: 2, Fits: true},
+		{Font: "a", Scale: 1, DW: 1, DH: 2, Fits: true},
+		{Font: "c", Scale: 1, DW: 0, DH: 7, Fits: true},
 	}
 
 	sortCandidates(candidates, PriorityWidth)
 
 	expected := []Candidate{
-		{Font: "c", Scale: 1, DW: 0, DH: 7},
-		{Font: "a", Scale: 1, DW: 1, DH: 2},
-		{Font: "a", Scale: 2, DW: 1, DH: 2},
-		{Font: "b", Scale: 1, DW: 1, DH: 4},
+		{Font: "c", Scale: 1, DW: 0, DH: 7, Fits: true},
+		{Font: "a", Scale: 1, DW: 1, DH: 2, Fits: true},
+		{Font: "a", Scale: 2, DW: 1, DH: 2, Fits: true},
+		{Font: "b", Scale: 1, DW: 1, DH: 4, Fits: true},
 	}
 
 	if !reflect.DeepEqual(candidates, expected) {
@@ -29,19 +29,19 @@ func TestSortCandidatesWidthPriority(t *testing.T) {
 
 func TestSortCandidatesHeightPriority(t *testing.T) {
 	candidates := []Candidate{
-		{Font: "b", Scale: 1, DW: 4, DH: 1},
-		{Font: "a", Scale: 2, DW: 2, DH: 1},
-		{Font: "a", Scale: 1, DW: 2, DH: 1},
-		{Font: "c", Scale: 1, DW: 7, DH: 0},
+		{Font: "b", Scale: 1, DW: 4, DH: 1, Fits: true},
+		{Font: "a", Scale: 2, DW: 2, DH: 1, Fits: true},
+		{Font: "a", Scale: 1, DW: 2, DH: 1, Fits: true},
+		{Font: "c", Scale: 1, DW: 7, DH: 0, Fits: true},
 	}
 
 	sortCandidates(candidates, PriorityHeight)
 
 	expected := []Candidate{
-		{Font: "c", Scale: 1, DW: 7, DH: 0},
-		{Font: "a", Scale: 1, DW: 2, DH: 1},
-		{Font: "a", Scale: 2, DW: 2, DH: 1},
-		{Font: "b", Scale: 1, DW: 4, DH: 1},
+		{Font: "c", Scale: 1, DW: 7, DH: 0, Fits: true},
+		{Font: "a", Scale: 1, DW: 2, DH: 1, Fits: true},
+		{Font: "a", Scale: 2, DW: 2, DH: 1, Fits: true},
+		{Font: "b", Scale: 1, DW: 4, DH: 1, Fits: true},
 	}
 
 	if !reflect.DeepEqual(candidates, expected) {

--- a/internal/fit/fit_test.go
+++ b/internal/fit/fit_test.go
@@ -1,0 +1,50 @@
+package fit
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestSortCandidatesWidthPriority(t *testing.T) {
+	candidates := []Candidate{
+		{Font: "b", Scale: 1, DW: 1, DH: 4},
+		{Font: "a", Scale: 2, DW: 1, DH: 2},
+		{Font: "a", Scale: 1, DW: 1, DH: 2},
+		{Font: "c", Scale: 1, DW: 0, DH: 7},
+	}
+
+	sortCandidates(candidates, PriorityWidth)
+
+	expected := []Candidate{
+		{Font: "c", Scale: 1, DW: 0, DH: 7},
+		{Font: "a", Scale: 1, DW: 1, DH: 2},
+		{Font: "a", Scale: 2, DW: 1, DH: 2},
+		{Font: "b", Scale: 1, DW: 1, DH: 4},
+	}
+
+	if !reflect.DeepEqual(candidates, expected) {
+		t.Fatalf("width priority order mismatch: got %#v", candidates)
+	}
+}
+
+func TestSortCandidatesHeightPriority(t *testing.T) {
+	candidates := []Candidate{
+		{Font: "b", Scale: 1, DW: 4, DH: 1},
+		{Font: "a", Scale: 2, DW: 2, DH: 1},
+		{Font: "a", Scale: 1, DW: 2, DH: 1},
+		{Font: "c", Scale: 1, DW: 7, DH: 0},
+	}
+
+	sortCandidates(candidates, PriorityHeight)
+
+	expected := []Candidate{
+		{Font: "c", Scale: 1, DW: 7, DH: 0},
+		{Font: "a", Scale: 1, DW: 2, DH: 1},
+		{Font: "a", Scale: 2, DW: 2, DH: 1},
+		{Font: "b", Scale: 1, DW: 4, DH: 1},
+	}
+
+	if !reflect.DeepEqual(candidates, expected) {
+		t.Fatalf("height priority order mismatch: got %#v", candidates)
+	}
+}

--- a/internal/fit/fit_test.go
+++ b/internal/fit/fit_test.go
@@ -7,19 +7,19 @@ import (
 
 func TestSortCandidatesWidthPriority(t *testing.T) {
 	candidates := []Candidate{
-		{Font: "b", Scale: 1, DW: 1, DH: 4, Fits: true},
-		{Font: "a", Scale: 2, DW: 1, DH: 2, Fits: true},
-		{Font: "a", Scale: 1, DW: 1, DH: 2, Fits: true},
-		{Font: "c", Scale: 1, DW: 0, DH: 7, Fits: true},
+		{Font: "b", ScaleIndex: 0, DW: 1, DH: 4, Fits: true},
+		{Font: "a", ScaleIndex: 1, DW: 1, DH: 2, Fits: true},
+		{Font: "a", ScaleIndex: 0, DW: 1, DH: 2, Fits: true},
+		{Font: "c", ScaleIndex: 0, DW: 0, DH: 7, Fits: true},
 	}
 
 	sortCandidates(candidates, PriorityWidth)
 
 	expected := []Candidate{
-		{Font: "c", Scale: 1, DW: 0, DH: 7, Fits: true},
-		{Font: "a", Scale: 1, DW: 1, DH: 2, Fits: true},
-		{Font: "a", Scale: 2, DW: 1, DH: 2, Fits: true},
-		{Font: "b", Scale: 1, DW: 1, DH: 4, Fits: true},
+		{Font: "c", ScaleIndex: 0, DW: 0, DH: 7, Fits: true},
+		{Font: "a", ScaleIndex: 1, DW: 1, DH: 2, Fits: true},
+		{Font: "a", ScaleIndex: 0, DW: 1, DH: 2, Fits: true},
+		{Font: "b", ScaleIndex: 0, DW: 1, DH: 4, Fits: true},
 	}
 
 	if !reflect.DeepEqual(candidates, expected) {
@@ -29,19 +29,19 @@ func TestSortCandidatesWidthPriority(t *testing.T) {
 
 func TestSortCandidatesHeightPriority(t *testing.T) {
 	candidates := []Candidate{
-		{Font: "b", Scale: 1, DW: 4, DH: 1, Fits: true},
-		{Font: "a", Scale: 2, DW: 2, DH: 1, Fits: true},
-		{Font: "a", Scale: 1, DW: 2, DH: 1, Fits: true},
-		{Font: "c", Scale: 1, DW: 7, DH: 0, Fits: true},
+		{Font: "b", ScaleIndex: 0, DW: 4, DH: 1, Fits: true},
+		{Font: "a", ScaleIndex: 1, DW: 2, DH: 1, Fits: true},
+		{Font: "a", ScaleIndex: 0, DW: 2, DH: 1, Fits: true},
+		{Font: "c", ScaleIndex: 0, DW: 7, DH: 0, Fits: true},
 	}
 
 	sortCandidates(candidates, PriorityHeight)
 
 	expected := []Candidate{
-		{Font: "c", Scale: 1, DW: 7, DH: 0, Fits: true},
-		{Font: "a", Scale: 1, DW: 2, DH: 1, Fits: true},
-		{Font: "a", Scale: 2, DW: 2, DH: 1, Fits: true},
-		{Font: "b", Scale: 1, DW: 4, DH: 1, Fits: true},
+		{Font: "c", ScaleIndex: 0, DW: 7, DH: 0, Fits: true},
+		{Font: "a", ScaleIndex: 1, DW: 2, DH: 1, Fits: true},
+		{Font: "a", ScaleIndex: 0, DW: 2, DH: 1, Fits: true},
+		{Font: "b", ScaleIndex: 0, DW: 4, DH: 1, Fits: true},
 	}
 
 	if !reflect.DeepEqual(candidates, expected) {


### PR DESCRIPTION
This PR adds an optional **fit mode** to the CLI that ranks and previews fonts based on how closely their rendered output matches a target width and/or height, letting users quickly find the best font and scale for a desired dimension, with optional display of measured dimensions and distance to the target.